### PR TITLE
feat: handle stale BLEDevices when an adapter goes offline

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 exclude = docs
-max-line-length = 88
+max-line-length = 120

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -218,35 +218,36 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
     best_path = device_path = device.details["path"]
     rssi_to_beat = device.rssi
 
-    with contextlib.suppress(Exception):
-        manager = await get_global_bluez_manager()
-        properties = manager._properties
-        if device_path not in properties:
-            # device has disappeared so take
-            # anything over the current path
-            rssi_to_beat = -1000
+    # with contextlib.suppress(Exception):
+    manager = await get_global_bluez_manager()
+    properties = manager._properties
+    if device_path not in properties:
+        # device has disappeared so take
+        # anything over the current path
+        rssi_to_beat = -1000
 
-        for path in _get_possible_paths(device_path):
-            if path not in properties or path == device_path:
-                continue
-            rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
-            if not rssi or rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
-                continue
-            best_path = path
-            rssi_to_beat = rssi
-            _LOGGER.debug(
-                "Found device %s at %s with better RSSI %s", device.address, path, rssi
-            )
+    for path in _get_possible_paths(device_path):
+        if path not in properties or path == device_path:
+            continue
+        rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
+        if not rssi or rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
+            continue
+        best_path = path
+        rssi_to_beat = rssi
+        _LOGGER.debug(
+            "Found device %s at %s with better RSSI %s", device.address, path, rssi
+        )
 
-        if best_path == device_path:
-            return None
+    if best_path == device_path:
+        return None
 
-        fresh_ble_device = copy(BLEDevice)
-        fresh_ble_device.details["path"] = best_path
-        fresh_ble_device.rssi = rssi_to_beat
-        return fresh_ble_device
+    fresh_ble_device = copy(BLEDevice)
+    fresh_ble_device.details["path"] = best_path
+    fresh_ble_device.rssi = rssi_to_beat
+    return fresh_ble_device
 
-    return None
+
+#    return None
 
 
 async def establish_connection(

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -216,7 +216,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
         properties = manager._properties
         for path in _get_possible_paths(device_path):
             if path in properties:
-                rssi = properties[path][defs.DEVICE_INTERFACE]["RSSI"]
+                rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
                 _LOGGER.debug(
                     "Found device %s at %s with RSSI %s", device.address, path, rssi
                 )

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -25,6 +25,8 @@ if CAN_CACHE_SERVICES:
             get_global_bluez_manager,
         )
 
+UNREACHABLE_RSSI = -1000
+
 BLEAK_HAS_SERVICE_CACHE_SUPPORT = (
     "dangerous_use_bleak_cache" in inspect.signature(BleakClient.connect).parameters
 )
@@ -214,7 +216,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
         return device
 
     best_path = device_path = device.details["path"]
-    rssi_to_beat = device_rssi = device.rssi
+    rssi_to_beat = device_rssi = device.rssi or UNREACHABLE_RSSI
 
     try:
         manager = await get_global_bluez_manager()
@@ -228,7 +230,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
             _LOGGER.debug(
                 "Device %s at %s has disappeared", device.address, device_path
             )
-            rssi_to_beat = device_rssi = -1000
+            rssi_to_beat = device_rssi = UNREACHABLE_RSSI
 
         for path in _get_possible_paths(device_path):
             if (

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -216,7 +216,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
         return device
 
     best_path = device_path = device.details["path"]
-    rssi_to_beat = device.rssi
+    rssi_to_beat = device_rssi = device.rssi
 
     # with contextlib.suppress(Exception):
     manager = await get_global_bluez_manager()
@@ -224,13 +224,15 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
     if device_path not in properties:
         # device has disappeared so take
         # anything over the current path
-        rssi_to_beat = -1000
+        device_rssi = -1000
 
     for path in _get_possible_paths(device_path):
         if path not in properties or path == device_path:
             continue
         rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
-        if not rssi or rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
+        if not rssi or rssi - RSSI_SWITCH_THRESHOLD < device_rssi:
+            continue
+        if rssi < rssi_to_beat:
             continue
         best_path = path
         rssi_to_beat = rssi

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -226,7 +226,11 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
         device_rssi = -1000
 
     for path in _get_possible_paths(device_path):
-        if path not in properties or path == device_path:
+        if (
+            path == device_path
+            or path not in properties
+            or defs.DEVICE_INTERFACE not in properties[path]
+        ):
             continue
         rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
         if not rssi or rssi - RSSI_SWITCH_THRESHOLD < device_rssi:

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -228,7 +228,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
             _LOGGER.debug(
                 "Device %s at %s has disappeared", device.address, device_path
             )
-            device_rssi = -1000
+            rssi_to_beat = device_rssi = -1000
 
         for path in _get_possible_paths(device_path):
             if (

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import copy
+
 __version__ = "1.10.1"
 
 
@@ -28,6 +30,9 @@ if CAN_CACHE_SERVICES:
 BLEAK_HAS_SERVICE_CACHE_SUPPORT = (
     "dangerous_use_bleak_cache" in inspect.signature(BleakClient.connect).parameters
 )
+
+
+RSSI_SWITCH_THRESHOLD = 6
 
 __all__ = [
     "establish_connection",
@@ -203,24 +208,43 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
     """Freshen the device.
 
     If the device is from BlueZ it may be stale
-    because bleak does not send callbaks if only
+    because bleak does not send callbacks if only
     the RSSI changes so we may need to find the
     path to the device ourselves.
     """
     if not isinstance(device.details, dict) or "path" not in device.details:
         return device
-    device_path = device.details["path"]
+
+    best_path = device_path = device.details["path"]
+    rssi_to_beat = device.rssi
 
     with contextlib.suppress(Exception):
         manager = await get_global_bluez_manager()
         properties = manager._properties
+        if device_path not in properties:
+            # device has disappeared so take
+            # anything over the current path
+            rssi_to_beat = -1000
+
         for path in _get_possible_paths(device_path):
-            if path in properties:
-                rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
-                _LOGGER.debug(
-                    "Found device %s at %s with RSSI %s", device.address, path, rssi
-                )
-        return None
+            if path not in properties or path == device_path:
+                continue
+            rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
+            if rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
+                continue
+            best_path = path
+            rssi_to_beat = rssi
+            _LOGGER.debug(
+                "Found device %s at %s with better RSSI %s", device.address, path, rssi
+            )
+
+        if best_path == device_path:
+            return None
+
+        fresh_ble_device = copy(BLEDevice)
+        fresh_ble_device.details["path"] = best_path
+        fresh_ble_device.rssi = rssi_to_beat
+        return fresh_ble_device
 
     return None
 

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -32,7 +32,13 @@ BLEAK_HAS_SERVICE_CACHE_SUPPORT = (
     "dangerous_use_bleak_cache" in inspect.signature(BleakClient.connect).parameters
 )
 
+
+# Make sure bleak and dbus-next have time
+# to run their cleanup callbacks or the
+# retry call will just fail in the same way.
 BLEAK_DBUS_BACKOFF_TIME = 0.25
+
+
 RSSI_SWITCH_THRESHOLD = 6
 
 __all__ = [

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -230,7 +230,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
             if path not in properties or path == device_path:
                 continue
             rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
-            if rssi and rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
+            if not rssi or rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
                 continue
             best_path = path
             rssi_to_beat = rssi

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -224,6 +224,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
     if device_path not in properties:
         # device has disappeared so take
         # anything over the current path
+        _LOGGER.debug("Device %s at %s has disappeared", device.address, device_path)
         device_rssi = -1000
 
     for path in _get_possible_paths(device_path):

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -230,7 +230,7 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
             if path not in properties or path == device_path:
                 continue
             rssi = properties[path][defs.DEVICE_INTERFACE].get("RSSI")
-            if rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
+            if rssi and rssi - RSSI_SWITCH_THRESHOLD < rssi_to_beat:
                 continue
             best_path = path
             rssi_to_beat = rssi

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from copy import copy
-
 __version__ = "1.10.1"
 
 
@@ -244,10 +242,13 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
     if best_path == device_path:
         return None
 
-    fresh_ble_device = copy(BLEDevice)
-    fresh_ble_device.details["path"] = best_path
-    fresh_ble_device.rssi = rssi_to_beat
-    return fresh_ble_device
+    return BLEDevice(
+        device.address,
+        device.name,
+        {**device.details, "path": best_path},
+        rssi_to_beat,
+        **device.metadata,
+    )
 
 
 #    return None

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -219,7 +219,10 @@ async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
     # with contextlib.suppress(Exception):
     manager = await get_global_bluez_manager()
     properties = manager._properties
-    if device_path not in properties:
+    if (
+        device_path not in properties
+        or defs.DEVICE_INTERFACE not in properties[device_path]
+    ):
         # device has disappeared so take
         # anything over the current path
         _LOGGER.debug("Device %s at %s has disappeared", device.address, device_path)


### PR DESCRIPTION
- We will try to freshen the device from
  the global BlueZ manager. If anything goes
  wrong we will use the potentially stale BLEDevice
  since we are not using a public api (there
  is no public api for this)