### PR TITLE
feat: do not disconnect unexpectedly connected devices if bleak supports reusing them

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -363,13 +363,13 @@ async def close_stale_connections(
                 connected_device, device
             ):
                 _LOGGER.debug(
-                    "%s - %s: Not disconnecting since bleak can use it",
+                    "%s - %s: unexpectedly connected, not disconnecting since only_other_adapters is set",
                     connected_device.name,
                     description,
                 )
             else:
                 _LOGGER.debug(
-                    "%s - %s: unexpectedly connected",
+                    "%s - %s: unexpectedly connected, disconnecting",
                     connected_device.name,
                     description,
                 )
@@ -459,6 +459,12 @@ async def establish_connection(
         raise BleakConnectionError(msg) from exc
 
     create_client = True
+
+    _LOGGER.debug(
+        "Bleak capabilities: already_connected_support=%s service_cache_support=%s",
+        BLEAK_HAS_ALREADY_CONNECTED_SUPPORT,
+        BLEAK_HAS_SERVICE_CACHE_SUPPORT,
+    )
 
     while True:
         attempt += 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +20,11 @@ from bleak_retry_connector import (
     get_connected_devices,
     get_device,
 )
+
+
+@pytest.fixture(autouse=True)
+def configure_test_logging(caplog):
+    caplog.set_level(logging.DEBUG)
 
 
 @pytest.mark.asyncio
@@ -711,6 +717,114 @@ async def test_establish_connection_better_rssi_available():
 
 
 @pytest.mark.asyncio
+async def test_establish_connection_other_adapter_already_connected():
+
+    device: BLEDevice | None = None
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, ble_device_or_address, *args, **kwargs):
+            ble_device_or_address.metadata["delegate"] = 0
+            super().__init__(ble_device_or_address, *args, **kwargs)
+            nonlocal device
+            device = ble_device_or_address
+            self._device_path = "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
+
+        async def connect(self, *args, **kwargs):
+            return True
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+        async def get_services(self, *args, **kwargs):
+            return []
+
+    class FakeBleakClientWithServiceCache(BleakClientWithServiceCache, FakeBleakClient):
+        """Fake BleakClientWithServiceCache."""
+
+        async def get_services(self, *args, **kwargs):
+            return []
+
+    collection = BleakGATTServiceCollection()
+
+    class FakeBluezManager:
+        def __init__(self):
+            self._properties = {
+                "/org/bluez/hci0/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -30,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci1/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "Connected": True,
+                        "RSSI": -79,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci2/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "Connected": False,
+                        "RSSI": -80,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci3/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -31,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+            }
+
+    bleak_retry_connector.get_global_bluez_manager = AsyncMock(
+        return_value=FakeBluezManager()
+    )
+    bleak_retry_connector.defs = defs
+
+    with patch.object(bleak_retry_connector, "CAN_CACHE_SERVICES", True):
+        client = await establish_connection(
+            FakeBleakClientWithServiceCache,
+            BLEDevice(
+                "aa:bb:cc:dd:ee:ff",
+                "name",
+                {"path": "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"},
+                -80,
+                delegate=False,
+            ),
+            "test",
+            disconnected_callback=MagicMock(),
+            cached_services=collection,
+        )
+
+    assert isinstance(client, FakeBleakClientWithServiceCache)
+    assert client._cached_services is None
+    await client.get_services() is collection
+    assert device is not None
+    assert device.details["path"] == "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"
+
+
+@pytest.mark.asyncio
 async def test_establish_connection_device_disappeared():
     class FakeBleakClient(BleakClient):
         def __init__(self, ble_device_or_address, *args, **kwargs):
@@ -956,7 +1070,7 @@ async def test_get_device_already_connected():
 
 
 @pytest.mark.asyncio
-async def test_establish_connection_better_rssi_available_already_connected():
+async def test_establish_connection_better_rssi_available_already_connected_no_already_connected_supported():
 
     device: BLEDevice | None = None
 
@@ -1061,6 +1175,8 @@ async def test_establish_connection_better_rssi_available_already_connected():
         bleak_retry_connector, "IS_LINUX", True
     ), patch.object(
         bleak_retry_connector, "CAN_CACHE_SERVICES", True
+    ), patch.object(
+        bleak_retry_connector, "BLEAK_HAS_ALREADY_CONNECTED_SUPPORT", False
     ):
         client = await establish_connection(
             FakeBleakClientWithServiceCache,
@@ -1080,7 +1196,7 @@ async def test_establish_connection_better_rssi_available_already_connected():
     assert client._cached_services is None
     await client.get_services() is collection
     assert device is not None
-    assert device.details["path"] == "/org/bluez/hci0/dev_FA_23_9D_AA_45_46"
+    assert device.details["path"] == "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"
     assert len(mock_disconnect_device.mock_calls) == 1
     assert (
         mock_disconnect_device.mock_calls[0][1][0][0].details["path"]
@@ -1088,5 +1204,140 @@ async def test_establish_connection_better_rssi_available_already_connected():
     )
     assert (
         mock_disconnect_device.mock_calls[0][1][0][1].details["path"]
+        == "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
+    )
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_better_rssi_available_already_connected_already_connected_supported():
+
+    device: BLEDevice | None = None
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, ble_device_or_address, *args, **kwargs):
+            ble_device_or_address.metadata["delegate"] = 0
+            super().__init__(ble_device_or_address, *args, **kwargs)
+            nonlocal device
+            device = ble_device_or_address
+            self._device_path = "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
+
+        async def connect(self, *args, **kwargs):
+            return True
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+        async def get_services(self, *args, **kwargs):
+            return []
+
+    class FakeBleakClientWithServiceCache(BleakClientWithServiceCache, FakeBleakClient):
+        """Fake BleakClientWithServiceCache."""
+
+        async def get_services(self, *args, **kwargs):
+            return []
+
+    collection = BleakGATTServiceCollection()
+
+    class FakeBluezManager:
+        def __init__(self):
+            self._properties = {
+                "/org/bluez/hci0/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -30,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci1/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Connected": True,
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -79,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci2/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Connected": True,
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -80,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci3/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -31,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+            }
+
+    bleak_retry_connector.get_global_bluez_manager = AsyncMock(
+        return_value=FakeBluezManager()
+    )
+    bleak_retry_connector.defs = defs
+
+    mock_device = BLEDevice(
+        "aa:bb:cc:dd:ee:ff",
+        "name",
+        {"path": "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"},
+        -80,
+        delegate=False,
+    )
+
+    connected = await get_connected_devices(mock_device)
+    assert len(connected) == 2
+    assert isinstance(connected[0], BLEDevice)
+    assert connected[0].details["path"] == "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"
+    assert connected[1].details["path"] == "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
+
+    with patch(
+        "bleak_retry_connector._disconnect_devices"
+    ) as mock_disconnect_device, patch.object(
+        bleak_retry_connector, "IS_LINUX", True
+    ), patch.object(
+        bleak_retry_connector, "CAN_CACHE_SERVICES", True
+    ), patch.object(
+        bleak_retry_connector, "BLEAK_HAS_ALREADY_CONNECTED_SUPPORT", True
+    ):
+        client = await establish_connection(
+            FakeBleakClientWithServiceCache,
+            BLEDevice(
+                "aa:bb:cc:dd:ee:ff",
+                "name",
+                {"path": "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"},
+                -80,
+                delegate=False,
+            ),
+            "test",
+            disconnected_callback=MagicMock(),
+            cached_services=collection,
+        )
+
+    assert isinstance(client, FakeBleakClientWithServiceCache)
+    assert client._cached_services is None
+    await client.get_services() is collection
+    assert device is not None
+    assert device.details["path"] == "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"
+    assert len(mock_disconnect_device.mock_calls) == 1
+    assert (
+        mock_disconnect_device.mock_calls[0][1][0][0].details["path"]
         == "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1181,7 +1181,7 @@ async def test_establish_connection_better_rssi_available_already_connected_no_a
         client = await establish_connection(
             FakeBleakClientWithServiceCache,
             BLEDevice(
-                "aa:bb:cc:dd:ee:ff",
+                "FA:23:9D:AA:45:46",
                 "name",
                 {"path": "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"},
                 -80,
@@ -1209,7 +1209,7 @@ async def test_establish_connection_better_rssi_available_already_connected_no_a
 
 
 @pytest.mark.asyncio
-async def test_establish_connection_better_rssi_available_already_connected_already_connected_supported():
+async def test_establish_connection_better_rssi_available_already_connected_supported_different_adapter():
 
     device: BLEDevice | None = None
 
@@ -1320,7 +1320,7 @@ async def test_establish_connection_better_rssi_available_already_connected_alre
         client = await establish_connection(
             FakeBleakClientWithServiceCache,
             BLEDevice(
-                "aa:bb:cc:dd:ee:ff",
+                "FA:23:9D:AA:45:46",
                 "name",
                 {"path": "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"},
                 -80,
@@ -1333,6 +1333,141 @@ async def test_establish_connection_better_rssi_available_already_connected_alre
 
     assert isinstance(client, FakeBleakClientWithServiceCache)
     assert client._cached_services is None
+    await client.get_services() is collection
+    assert device is not None
+    assert device.details["path"] == "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"
+    assert len(mock_disconnect_device.mock_calls) == 1
+    assert (
+        mock_disconnect_device.mock_calls[0][1][0][0].details["path"]
+        == "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
+    )
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_better_rssi_available_already_connected_supported_same_adapter():
+
+    device: BLEDevice | None = None
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, ble_device_or_address, *args, **kwargs):
+            ble_device_or_address.metadata["delegate"] = 0
+            super().__init__(ble_device_or_address, *args, **kwargs)
+            nonlocal device
+            device = ble_device_or_address
+            self._device_path = "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
+
+        async def connect(self, *args, **kwargs):
+            return True
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+        async def get_services(self, *args, **kwargs):
+            return []
+
+    class FakeBleakClientWithServiceCache(BleakClientWithServiceCache, FakeBleakClient):
+        """Fake BleakClientWithServiceCache."""
+
+        async def get_services(self, *args, **kwargs):
+            return []
+
+    collection = BleakGATTServiceCollection()
+
+    class FakeBluezManager:
+        def __init__(self):
+            self._properties = {
+                "/org/bluez/hci0/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -30,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci1/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Connected": True,
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -79,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci2/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Connected": True,
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -80,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+                "/org/bluez/hci3/dev_FA_23_9D_AA_45_46": {
+                    "UUID": "service",
+                    "Primary": True,
+                    "Characteristics": [],
+                    defs.DEVICE_INTERFACE: {
+                        "Address": "FA:23:9D:AA:45:46",
+                        "Alias": "FA:23:9D:AA:45:46",
+                        "RSSI": -31,
+                    },
+                    defs.GATT_SERVICE_INTERFACE: True,
+                },
+            }
+
+    bleak_retry_connector.get_global_bluez_manager = AsyncMock(
+        return_value=FakeBluezManager()
+    )
+    bleak_retry_connector.defs = defs
+
+    mock_device = BLEDevice(
+        "aa:bb:cc:dd:ee:ff",
+        "name",
+        {"path": "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"},
+        -80,
+        delegate=False,
+    )
+
+    connected = await get_connected_devices(mock_device)
+    assert len(connected) == 2
+    assert isinstance(connected[0], BLEDevice)
+    assert connected[0].details["path"] == "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"
+    assert connected[1].details["path"] == "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"
+
+    with patch(
+        "bleak_retry_connector._disconnect_devices"
+    ) as mock_disconnect_device, patch.object(
+        bleak_retry_connector, "IS_LINUX", True
+    ), patch.object(
+        bleak_retry_connector, "CAN_CACHE_SERVICES", True
+    ), patch.object(
+        bleak_retry_connector, "BLEAK_HAS_ALREADY_CONNECTED_SUPPORT", True
+    ):
+        client = await establish_connection(
+            FakeBleakClientWithServiceCache,
+            BLEDevice(
+                "FA:23:9D:AA:45:46",
+                "name",
+                {"path": "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"},
+                -80,
+                delegate=False,
+            ),
+            "test",
+            disconnected_callback=MagicMock(),
+            cached_services=collection,
+        )
+
+    assert isinstance(client, FakeBleakClientWithServiceCache)
+    assert client._cached_services is not None
     await client.get_services() is collection
     assert device is not None
     assert device.details["path"] == "/org/bluez/hci1/dev_FA_23_9D_AA_45_46"


### PR DESCRIPTION
Bleak 0.17 supports connecting to devices that are already connected in BlueZ.

We now detect this and adjust the BLEDevice to point to the already
connected device so they do not have to wait for a connection.

This also fixes a race where the connection times out but the connection is actually
made on the bus but we think it failed because we hit the timeout, so the next attempt
will instead sail right though and be connected.