### PR TITLE
fix: set disconnected_callback in the constructor for newer bleak compat

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -448,9 +448,9 @@ async def establish_connection(
         )
 
         if create_client:
-            client = client_class(device, **kwargs)
-            if disconnected_callback:
-                client.set_disconnected_callback(disconnected_callback)
+            client = client_class(
+                device, disconnected_callback=disconnected_callback, **kwargs
+            )
             create_client = False
 
         if IS_LINUX:


### PR DESCRIPTION
Bleak now wants the disconnected_callback in the constructor

need to update aiohomekit as well
`Sep 26 05:03:12 homeassistant homeassistant[485]: TypeError: AIOHomeKitBleakClient.__init__() got an unexpected keyword argument 'disconnected_callback'`