### PR TITLE
fix: missing backoff execution with esp32

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -384,6 +384,7 @@ async def wait_for_disconnect(device: BLEDevice, min_wait_time: float) -> None:
         or not isinstance(device.details, dict)
         or "path" not in device.details
     ):
+        await asyncio.sleep(min_wait_time)
         return
     start = time.monotonic() if min_wait_time else 0
     try:


### PR DESCRIPTION
Since the devices were not bluez devices we did not sleep the min wait time