### PR TITLE
fix: reduce logging as timeouts are expected

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -538,7 +538,6 @@ async def establish_connection(
                     description,
                     attempt,
                     rssi,
-                    exc_info=True,
                 )
             backoff_time = calculate_backoff_time(exc)
             await wait_for_disconnect(device, backoff_time)


### PR DESCRIPTION
When we were debugging the esphome timeouts, logging the full trace was useful, but now it is is too noisy as timeouts are expected and we have moved on to fixing other issues