### PR TITLE
fix: stop trying to check dbus once the socket is missing

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -353,7 +353,9 @@ async def get_bluez_device(
     except FileNotFoundError as ex:
         setattr(get_bluez_device, "_has_dbus_socket", False)
         _LOGGER.debug(
-            "Dbus socket not found, will not try again until next restart: %s", ex
+            "Dbus socket at %s not found, will not try again until next restart: %s",
+            ex.filename,
+            ex,
         )
     except Exception as ex:  # pylint: disable=broad-except
         _LOGGER.debug(


### PR DESCRIPTION
Each call to get_device would try over and over to connect to dbus when the socket is missing. This is normal when dbus is not setup and only using bluetooth proxies
fixes #69