### PR TITLE
fix: enable service cache by default since esp32s are unreliable without it

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -504,7 +504,7 @@ async def establish_connection(
     max_attempts: int = MAX_CONNECT_ATTEMPTS,
     cached_services: BleakGATTServiceCollection | None = None,
     ble_device_callback: Callable[[], BLEDevice] | None = None,
-    use_services_cache: bool = False,
+    use_services_cache: bool = True,
     **kwargs: Any,
 ) -> BleakClient:
     """Establish a connection to the device."""


### PR DESCRIPTION
We have been using this with almost every integration for a long time, and its
proven itself. Flip the default to True as the esp32s are unreliable without it
anyways