### PR TITLE
feat: add function to clear the cache

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -172,8 +172,12 @@ class BleakClientWithServiceCache(BleakClient):
         This was only kept for backwards compatibility.
         """
 
-    async def clear_cache(self) -> None:
+    async def clear_cache(self) -> bool:
         """Clear the cached services."""
+        if hasattr(super(), "clear_cache"):
+            return await super().clear_cache()
+        _LOGGER.warning("clear_cache not implemented in bleak version")
+        return False
 
 
 def ble_device_has_changed(original: BLEDevice, new: BLEDevice) -> bool:

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -187,6 +187,19 @@ def ble_device_has_changed(original: BLEDevice, new: BLEDevice) -> bool:
     )
 
 
+async def clear_cache(address: str) -> bool:
+    """Clear the cache for a device."""
+    if not IS_LINUX or not await get_device(address):
+        return False
+    with contextlib.suppress(Exception):
+        manager = await get_global_bluez_manager()
+        manager._services_cache.pop(
+            address.upper(), None
+        )  # pylint: disable=protected-access
+        return True
+    return False
+
+
 def ble_device_description(device: BLEDevice) -> str:
     """Get the device description."""
     details = device.details

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -172,6 +172,9 @@ class BleakClientWithServiceCache(BleakClient):
         This was only kept for backwards compatibility.
         """
 
+    async def clear_cache(self) -> None:
+        """Clear the cached services."""
+
 
 def ble_device_has_changed(original: BLEDevice, new: BLEDevice) -> bool:
     """Check if the device has changed."""


### PR DESCRIPTION
Sometimes the ESP32 or the BlueZ stack will resolve services incorrectly so we need a way to clear the cache