### PR TITLE
feat: remove freshen fallback logic since Home Assistant always provides us the best path to the device now

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -319,11 +319,6 @@ async def establish_connection(
     connect_errors = 0
     transient_errors = 0
     attempt = 0
-    # Its possible the BLEDevice can change between
-    # between connection attempts so we do not want
-    # to keep trying to connect to the old one if it has changed.
-    if ble_device_callback is not None:
-        device = ble_device_callback()
 
     def _raise_if_needed(name: str, description: str, exc: Exception) -> None:
         """Raise if we reach the max attempts."""

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -344,13 +344,13 @@ async def establish_connection(
 
     debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
     rssi: int | None = None
-    client = client_class(device, disconnected_callback=disconnected_callback, **kwargs)
-    if IS_LINUX:
-        # Bleak 0.17 will handle already connected devices for us, but
-        # we still need to disconnect if its unexpectedly connected to another
-        # adapter.
+    if IS_LINUX and (devices := await get_connected_devices(device)):
+        # Bleak 0.17 will handle already connected devices for us so
+        # if we are already connected we swap the device to the connected
+        # device.
+        device = devices[0]
 
-        await close_stale_connections(device, only_other_adapters=True)
+    client = client_class(device, disconnected_callback=disconnected_callback, **kwargs)
 
     while True:
         attempt += 1

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -248,7 +248,8 @@ def calculate_backoff_time(exc: Exception) -> float:
 
 async def _disconnect_devices(devices: list[BLEDevice]) -> None:
     """Disconnect the devices."""
-    await disconnect_devices(devices)
+    if IS_LINUX:
+        await disconnect_devices(devices)
 
 
 async def close_stale_connections(

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -22,7 +22,6 @@ from .bluez import (  # noqa: F401
     _get_properties,
     clear_cache,
     device_source,
-    get_bluez_device,
     get_connected_devices,
     get_device,
     get_device_by_adapter,

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -217,24 +217,6 @@ def ble_device_description(device: BLEDevice) -> str:
     return base_name
 
 
-async def freshen_ble_device(device: BLEDevice) -> BLEDevice | None:
-    """Freshen the device.
-
-    There may be a better path to the device on another adapter
-    that was seen after the code that provided the BLEDevice to
-    the establish_connection function was run.
-    """
-    if (
-        not IS_LINUX
-        or not isinstance(device.details, dict)
-        or "path" not in device.details
-    ):
-        return None
-    return await get_bluez_device(
-        device.name or device.address, device.details["path"], _get_rssi(device)
-    )
-
-
 def calculate_backoff_time(exc: Exception) -> float:
     """Calculate the backoff time based on the exception."""
 
@@ -294,13 +276,6 @@ async def close_stale_connections(
     if not to_disconnect:
         return
     await _disconnect_devices(to_disconnect)
-
-
-def _get_rssi(device: BLEDevice) -> int:
-    """Get the RSSI for the device."""
-    if not isinstance(device.details, dict) or "props" not in device.details:
-        return device.rssi
-    return device.details["props"].get("RSSI") or device.rssi or NO_RSSI_VALUE
 
 
 async def establish_connection(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def configure_test_logging(caplog):
 def mock_linux():
     with patch.object(bleak_retry_connector, "IS_LINUX", True), patch.object(
         bleak_retry_connector.bluez, "IS_LINUX", True
-    ):
+    ), patch("bleak.backends.scanner.platform.system", return_value="Linux"):
         yield
 
 


### PR DESCRIPTION
related https://github.com/home-assistant/core/pull/84512