### PR TITLE
fix: only import from bluetooth_adapters when running on linux

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -15,7 +15,6 @@ from bleak import BleakClient, BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
-from bluetooth_adapters import load_history_from_managed_objects
 
 from .bluez import (  # noqa: F401
     BleakSlotManager,
@@ -34,6 +33,8 @@ DISCONNECT_TIMEOUT = 5
 DEFAULT_ATTEMPTS = 2
 
 if IS_LINUX:
+    from bluetooth_adapters import load_history_from_managed_objects
+
     from .dbus import disconnect_devices
 
 


### PR DESCRIPTION
This avoids an exception on Windows because socket.CMSG_LEN is only available on UNIX platforms.

```
  File "bleak_retry_connector/__init__.py", line 18, in <module>
    from bluetooth_adapters import load_history_from_managed_objects
  File "bluetooth_adapters/__init__.py", line 12, in <module>
    from .dbus import (
  File "bluetooth_adapters/dbus.py", line 10, in <module>
    from dbus_fast import BusType, Message, MessageType, unpack_variants
  File "dbus_fast/__init__.py", line 1, in <module>
    from . import aio, glib, introspection, message_bus, proxy_object, service
  File "dbus_fast/aio/__init__.py", line 1, in <module>
    from .message_bus import MessageBus
  File "dbus_fast/aio\message_bus.py", line 29, in <module>
    from .message_reader import build_message_reader
  File "dbus_fast/aio/message_reader.py", line 7, in <module>
    from .._private.unmarshaller import Unmarshaller
  File "dbus_fast/_private/unmarshaller.py", line 16, in <module>
    UNIX_FDS_CMSG_LENGTH = socket.CMSG_LEN(MAX_UNIX_FDS_SIZE)
AttributeError: module 'socket' has no attribute 'CMSG_LEN'
```