### PR TITLE
fix: typing for generic BleakClient classes and the retry_bluetooth_connection_error decorator

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -279,17 +279,20 @@ async def close_stale_connections(
     await _disconnect_devices(to_disconnect)
 
 
+AnyBleakClient = TypeVar("AnyBleakClient", bound=BleakClient)
+
+
 async def establish_connection(
-    client_class: type[BleakClient],
+    client_class: type[AnyBleakClient],
     device: BLEDevice,
     name: str,
-    disconnected_callback: Callable[[BleakClient], None] | None = None,
+    disconnected_callback: Callable[[AnyBleakClient], None] | None = None,
     max_attempts: int = MAX_CONNECT_ATTEMPTS,
     cached_services: BleakGATTServiceCollection | None = None,
     ble_device_callback: Callable[[], BLEDevice] | None = None,
     use_services_cache: bool = True,
     **kwargs: Any,
-) -> BleakClient:
+) -> AnyBleakClient:
     """Establish a connection to the device."""
     timeouts = 0
     connect_errors = 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1432,7 +1432,7 @@ def test_calculate_backoff_time():
 async def test_retry_bluetooth_connection_error():
     """Test that the retry_bluetooth_connection_error decorator works correctly."""
 
-    @retry_bluetooth_connection_error()  # type: ignore[misc]
+    @retry_bluetooth_connection_error()
     async def test_function():
         raise BleakDBusError(MagicMock(), MagicMock())
 
@@ -1450,7 +1450,7 @@ async def test_retry_bluetooth_connection_error():
 async def test_retry_bluetooth_connection_error_non_default_max_attempts():
     """Test that the retry_bluetooth_connection_error decorator works correctly with a different number of retries."""
 
-    @retry_bluetooth_connection_error(4)  # type: ignore[misc]
+    @retry_bluetooth_connection_error(4)
     async def test_function():
         raise BleakDBusError(MagicMock(), MagicMock())
 


### PR DESCRIPTION
This should be the correct way of dealing with both of these types and mypy.