### PR TITLE
fix: ensure timeouts work with py3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Sphinx = {version = "^5.0", optional = true}
 sphinx-rtd-theme = {version = "^1.0", optional = true}
 myst-parser = {version = "^0.18", optional = true}
 bleak = ">=0.21.0"
-async-timeout = ">=4.0.1"
+async-timeout = {version = ">=3.0.0", python = "<3.11"}
 dbus-fast = {version = ">=1.14.0", markers = "platform_system == \"Linux\""}
 bluetooth-adapters = {version = ">=0.15.2", markers = "platform_system == \"Linux\""}
 

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -8,7 +8,6 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, ParamSpec, TypeVar
 
-import async_timeout
 from bleak import BleakClient, BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
@@ -26,6 +25,7 @@ from .bluez import (  # noqa: F401
     wait_for_disconnect,
 )
 from .const import IS_LINUX, NO_RSSI_VALUE, RSSI_SWITCH_THRESHOLD
+from .util import asyncio_timeout
 
 DISCONNECT_TIMEOUT = 5
 
@@ -346,7 +346,7 @@ async def establish_connection(
             )
 
         try:
-            async with async_timeout.timeout(BLEAK_SAFETY_TIMEOUT):
+            async with asyncio_timeout(BLEAK_SAFETY_TIMEOUT):
                 await client.connect(
                     timeout=BLEAK_TIMEOUT,
                     dangerous_use_bleak_cache=use_services_cache

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -7,11 +7,11 @@ import time
 from collections.abc import Generator
 from typing import Any
 
-import async_timeout
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
 from .const import IS_LINUX, NO_RSSI_VALUE, RSSI_SWITCH_THRESHOLD
+from .util import asyncio_timeout
 
 DISCONNECT_TIMEOUT = 5
 DBUS_CONNECT_TIMEOUT = 8.5
@@ -48,7 +48,7 @@ async def get_global_bluez_manager_with_timeout() -> "BlueZManager" | None:
         return None
 
     try:
-        async with async_timeout.timeout(DBUS_CONNECT_TIMEOUT):
+        async with asyncio_timeout(DBUS_CONNECT_TIMEOUT):
             return await get_global_bluez_manager()
     except FileNotFoundError as ex:
         setattr(get_global_bluez_manager_with_timeout, "_has_dbus_socket", False)
@@ -304,7 +304,7 @@ async def wait_for_disconnect(device: BLEDevice, min_wait_time: float) -> None:
     start = time.monotonic() if min_wait_time else 0
     try:
         manager = await get_global_bluez_manager()
-        async with async_timeout.timeout(DISCONNECT_TIMEOUT):
+        async with asyncio_timeout(DISCONNECT_TIMEOUT):
             await manager._wait_condition(device.details["path"], "Connected", False)
         end = time.monotonic() if min_wait_time else 0
         waited = end - start

--- a/src/bleak_retry_connector/dbus.py
+++ b/src/bleak_retry_connector/dbus.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import contextlib
 
-import async_timeout
 from bleak.backends.bluezdbus import defs
 from bleak.backends.device import BLEDevice
 from dbus_fast.aio.message_bus import MessageBus
 from dbus_fast.constants import BusType
 from dbus_fast.message import Message
+
+from .util import asyncio_timeout
 
 DISCONNECT_TIMEOUT = 5
 
@@ -24,7 +25,7 @@ async def disconnect_devices(devices: list[BLEDevice]) -> None:
     bus = await MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True).connect()
     for device in valid_devices:
         with contextlib.suppress(Exception):
-            async with async_timeout.timeout(DISCONNECT_TIMEOUT):
+            async with asyncio_timeout(DISCONNECT_TIMEOUT):
                 await bus.call(
                     Message(
                         destination=defs.BLUEZ_SERVICE,

--- a/src/bleak_retry_connector/util.py
+++ b/src/bleak_retry_connector/util.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout  # noqa: F401
+else:
+    from asyncio import timeout as asyncio_timeout  # noqa: F401


### PR DESCRIPTION
async_timeout < 4.0.3 did not work correctly with py3.11, we now use asyncio.timeout on py3.11