### PR TITLE
feat: handle services changed during connecting

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -373,7 +373,9 @@ async def establish_connection(
             await wait_for_disconnect(device, backoff_time)
             _raise_if_needed(name, device.address, exc)
         except KeyError as exc:
-            # Likely: KeyError: 'org.bluez.GattService1'
+            # Likely: KeyError: 'org.bluez.GattService1' from bleak
+            # ideally we would get a better error from bleak, but this is
+            # better than nothing.
             # self._properties[service_path][defs.GATT_SERVICE_INTERFACE]
             transient_errors += 1
             if debug_enabled:
@@ -388,6 +390,7 @@ async def establish_connection(
             if isinstance(client, BleakClientWithServiceCache):
                 await client.clear_cache()
                 await client.disconnect()
+                backoff_time = calculate_backoff_time(exc)
                 await wait_for_disconnect(device, backoff_time)
             _raise_if_needed(name, device.address, exc)
         except BrokenPipeError as exc:


### PR DESCRIPTION
fixes #107

```
2023-10-25 17:10:38.888 ERROR (MainThread) [homeassistant.components.improv_ble.config_flow] Unexpected exception
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/improv_ble/config_flow.py", line 399, in _try_call
    return await func
           ^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/improv_ble_client/client.py", line 184, in can_identify
    return await self._execute(_can_identify)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/bleak_retry_connector/__init__.py", line 471, in _async_wrap_bluetooth_connection_error_retry
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/improv_ble_client/client.py", line 291, in _execute
    await self._ensure_connected()
  File "/usr/local/lib/python3.11/site-packages/improv_ble_client/client.py", line 323, in _ensure_connected
    client = await establish_connection(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/bleak_retry_connector/__init__.py", line 350, in establish_connection
    await client.connect(
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/wrappers.py", line 292, in connect
    connected = await super().connect(**kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/bleak/__init__.py", line 605, in connect
    return await self._backend.connect(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/bleak/backends/bluezdbus/client.py", line 268, in connect
    await self.get_services(
  File "/usr/local/lib/python3.11/site-packages/bleak/backends/bluezdbus/client.py", line 656, in get_services
    self.services = await manager.get_services(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/bleak/backends/bluezdbus/manager.py", line 651, in get_services
    self._properties[service_path][defs.GATT_SERVICE_INTERFACE],
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'org.bluez.GattService1'
```