### PR TITLE
Treat ESP_GATT_CONN_CONN_CANCEL as out-of-slots error

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -121,7 +121,18 @@ TRANSIENT_ERRORS_MEDIUM_BACKOFF = {
 
 DEVICE_MISSING_ERRORS = {"org.freedesktop.DBus.Error.UnknownObject"}
 
-OUT_OF_SLOTS_ERRORS = {"available connection", "connection slot"}
+# ESP_GATT_CONN_CONN_CANCEL (0x100) indicates the ESP32 rejected the connection due to
+# limited resources (HCI error 0x0d). This happens when ESPHome incorrectly marks a
+# connection slot as free at ESP_GATTC_DISCONNECT_EVT instead of waiting for
+# ESP_GATTC_CLOSE_EVT, causing a race where we try to use a slot that isn't actually
+# available yet. The 4-second backoff gives time for the slot to truly become available
+# and for the state to sync with Home Assistant.
+# See: https://github.com/espressif/esp-idf/issues/17452
+OUT_OF_SLOTS_ERRORS = {
+    "available connection",
+    "connection slot",
+    "ESP_GATT_CONN_CONN_CANCEL",
+}
 
 TRANSIENT_ERRORS = {
     "le-connection-abort-by-local",
@@ -129,7 +140,6 @@ TRANSIENT_ERRORS = {
     "ESP_GATT_CONN_FAIL_ESTABLISH",
     "ESP_GATT_CONN_TERMINATE_PEER_USER",
     "ESP_GATT_CONN_TERMINATE_LOCAL_HOST",
-    "ESP_GATT_CONN_CONN_CANCEL",
 } | OUT_OF_SLOTS_ERRORS
 
 # Currently the same as transient error


### PR DESCRIPTION
## Summary

This PR fixes an issue where `ESP_GATT_CONN_CONN_CANCEL` errors from ESP32 devices were incorrectly treated as transient connection errors instead of resource exhaustion errors. This error occurs due to a race condition in ESPHome's connection slot management.

## Problem

ESP32 devices running ESPHome have a race condition where connection slots are marked as free too early:
- ESPHome marks slots as available at `ESP_GATTC_DISCONNECT_EVT` 
- The ESP32 controller needs more time to fully release resources
- Immediate reconnection attempts fail with `ESP_GATT_CONN_CONN_CANCEL` (HCI error 0x0d - "Connection Rejected Due to Limited Resources")
- The controller requires `ESP_GATTC_CLOSE_EVT` to fully clean up L2CAP channels, ATT resources, and HCI connection handles

## Solution

- Moved `ESP_GATT_CONN_CONN_CANCEL` from `TRANSIENT_ERRORS` to `OUT_OF_SLOTS_ERRORS`
- This applies a 4-second backoff instead of 0.25 seconds
- Raises `BleakOutOfConnectionSlotsError` with appropriate user guidance
- Provides time for the ESP32 to complete resource cleanup and sync state with Home Assistant

## Impact

- Prevents rapid reconnection attempts that would fail anyway
- Reduces unnecessary load on ESP32 devices
- Improves connection reliability with ESP32-based Bluetooth proxies
- Works around the issue even on unpatched ESPHome installations

## Related Issues

- ESPHome fix: https://github.com/esphome/esphome/pull/10303 - Addresses the root cause by deferring slot release until `ESP_GATTC_CLOSE_EVT`
- ESP-IDF issue: https://github.com/espressif/esp-idf/issues/17452 - Documents the underlying ESP32 behavior where connections completing too quickly cause resource tracking issues

## Testing

Added tests to verify:
- `ESP_GATT_CONN_CONN_CANCEL` receives the 4-second `OUT_OF_SLOTS_BACKOFF_TIME`
- The error is raised as `BleakOutOfConnectionSlotsError` with appropriate advice about adding additional proxies
- All existing tests continue to pass