### PR TITLE
fix: prevent KeyError when adapter unplugged during connection

### DIFF
--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -124,7 +124,7 @@ class BleakSlotManager:
     def get_allocations(self, adapter: str) -> Allocations:
         """Get the allocations."""
         slots = self._adapter_slots.get(adapter, 0)
-        allocated = []
+        allocated: list[str] = []
         if adapter in self._allocations_by_adapter:
             allocated = [
                 address_from_path(path)

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -124,15 +124,18 @@ class BleakSlotManager:
     def get_allocations(self, adapter: str) -> Allocations:
         """Get the allocations."""
         slots = self._adapter_slots.get(adapter, 0)
-        allocated = [
-            address_from_path(path) for path in self._allocations_by_adapter[adapter]
-        ]
+        allocated = []
+        if adapter in self._allocations_by_adapter:
+            allocated = [
+                address_from_path(path)
+                for path in self._allocations_by_adapter[adapter]
+            ]
         free = slots - len(allocated)
         return Allocations(adapter, slots, free, allocated)
 
     def _get_allocations(self, adapter: str) -> list[str]:
         """Get connected path allocations."""
-        if self._manager is None:
+        if self._manager is None or adapter not in self._allocations_by_adapter:
             return []
         return list(self._allocations_by_adapter[adapter])
 
@@ -204,6 +207,12 @@ class BleakSlotManager:
         """Unconditional release of the slot."""
         assert self._manager is not None  # nosec
         adapter = adapter_from_path(path)
+        if adapter not in self._allocations_by_adapter:
+            # Adapter was already removed (e.g., unplugged)
+            _LOGGER.debug(
+                "Cannot release slot for %s: adapter %s not found", path, adapter
+            )
+            return
         allocations = self._allocations_by_adapter[adapter]
         if watcher := allocations.pop(path, None):
             self._manager.remove_device_watcher(watcher)


### PR DESCRIPTION
## Summary

This PR fixes a KeyError exception that occurs when a Bluetooth adapter is unplugged while a device connection is in progress. The issue happens because the disconnect callback tries to release a slot for an adapter that has already been removed from the internal tracking structures.

```
2025-08-21 13:49:44.356 ERROR (MainThread) [dbus_fast.message_bus] A message handler raised an exception: 'hci1'
Traceback (most recent call last):
  File "src/dbus_fast/message_bus.py", line 797, in dbus_fast.message_bus.BaseMessageBus._process_message
  File "/usr/local/lib/python3.13/site-packages/bleak/backends/bluezdbus/manager.py", line 1077, in _parse_msg
    watcher.on_connected_changed(new_connected)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/bleak_retry_connector/bluez.py", line 184, in _on_device_connected_changed
    self._release_slot(path)
    ~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.13/site-packages/bleak_retry_connector/bluez.py", line 207, in _release_slot
    allocations = self._allocations_by_adapter[adapter]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'hci1'


```

## Problem

When a Bluetooth adapter gets unplugged during an active connection:
1. The adapter is removed from `_allocations_by_adapter` dict
2. The connection status change callback still fires for the disconnection
3. The `_release_slot` method tries to access the removed adapter, causing:
```python
KeyError: 'hci1'
```

## Solution

Added defensive checks to handle missing adapters gracefully:

### 1. `_release_slot` method
- Check if adapter exists before accessing allocations
- Log debug message and return early if adapter not found
- Prevents KeyError when disconnect events fire after adapter removal

### 2. `get_allocations` and `_get_allocations` methods  
- Added safety checks to handle missing adapters
- Return empty allocations instead of raising KeyError
- Ensures diagnostic/status methods work even after adapter removal

## Testing

Added comprehensive test `test_slot_manager_adapter_removal_during_disconnect` that:
- Sets up a connected device on an adapter
- Removes the adapter (simulating unplug)
- Triggers the disconnect callback
- Verifies no KeyError is raised and methods handle missing adapter gracefully

