### PR TITLE
feat(bluez): clear stale BlueZ state after connection failures

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -587,6 +587,19 @@ async def establish_connection(
         # Ensure the disconnect callback
         # has a chance to run before we try to reconnect
         await asyncio.sleep(0)
+        # Clear stale BlueZ state after any connection failure.
+        # Phantom connections, stale cache entries, or corrupted D-Bus
+        # state can cause every retry to fail the same way unless we
+        # actively clean up.  clear_cache() sends RemoveDevice via
+        # D-Bus, forcing fresh discovery on the next attempt.  It is
+        # a no-op on non-Linux and suppresses all exceptions internally.
+        if await clear_cache(device.address):
+            if debug_enabled:
+                _LOGGER.debug(
+                    "%s - %s: Cleared stale BlueZ state after connection failure",
+                    name,
+                    device.address,
+                )
 
     raise RuntimeError("This should never happen")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2346,3 +2346,187 @@ async def test_has_valid_services_in_cache_esphome_proxy(mock_linux):
     # Should return True for non-BlueZ devices (ESPHome proxy)
     result = await bleak_retry_connector._has_valid_services_in_cache(device)
     assert result is True
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_clears_stale_state_on_failure():
+    """Test that clear_cache is called after a connection failure to clean up
+    stale BlueZ state before the next retry attempt."""
+    attempts = 0
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise BleakError("test error")
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+        patch(
+            "bleak_retry_connector.clear_cache", new_callable=AsyncMock
+        ) as mock_clear,
+    ):
+        mock_clear.return_value = True
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    assert attempts == 2
+    assert mock_clear.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_clears_stale_state_on_timeout():
+    """Test that clear_cache is called after a timeout to clean up
+    phantom connections that cause connect to hang."""
+    attempts = 0
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise asyncio.TimeoutError()
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+        patch(
+            "bleak_retry_connector.clear_cache", new_callable=AsyncMock
+        ) as mock_clear,
+    ):
+        mock_clear.return_value = True
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    assert attempts == 2
+    assert mock_clear.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_no_clear_on_success():
+    """Test that clear_cache is NOT called when connection succeeds."""
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with patch(
+        "bleak_retry_connector.clear_cache", new_callable=AsyncMock
+    ) as mock_clear:
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    assert mock_clear.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_clears_on_each_failure():
+    """Test that clear_cache is called after every failed attempt,
+    not just the first one."""
+    attempts = 0
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise BleakError("le-connection-abort-by-local")
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+        patch(
+            "bleak_retry_connector.clear_cache", new_callable=AsyncMock
+        ) as mock_clear,
+    ):
+        mock_clear.return_value = True
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    assert attempts == 3
+    # clear_cache called once after each of the 2 failures
+    assert mock_clear.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_clears_on_broken_pipe():
+    """Test that clear_cache is called after BrokenPipeError."""
+    attempts = 0
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise BrokenPipeError()
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with patch(
+        "bleak_retry_connector.clear_cache", new_callable=AsyncMock
+    ) as mock_clear:
+        mock_clear.return_value = True
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    assert attempts == 2
+    assert mock_clear.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_clears_on_eof_error():
+    """Test that clear_cache is called after EOFError."""
+    attempts = 0
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise EOFError()
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+        patch(
+            "bleak_retry_connector.clear_cache", new_callable=AsyncMock
+        ) as mock_clear,
+    ):
+        mock_clear.return_value = True
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    assert attempts == 2
+    assert mock_clear.call_count == 1


### PR DESCRIPTION
## Summary

- After any connection failure in `establish_connection()`, call `clear_cache()` to remove stale BlueZ state before the next retry attempt.
- Without this, stale BlueZ state (phantom connections, stale cache entries, corrupted D-Bus state) can cause every retry to fail the same way, exhausting all attempts without recovery.
- `clear_cache()` sends `RemoveDevice` via D-Bus, forcing fresh device discovery on the next attempt.

## Problem

When a connection attempt fails, BlueZ may retain stale state for the device — cached services from a previous session, phantom `Connected=True` flags, or other D-Bus artifacts. The current retry loop retries against this same stale state, often failing identically on every attempt.

This is particularly impactful on embedded Linux systems (e.g., Venus OS / Cerbo GX) where multiple BLE services share adapters and stale state accumulates from process crashes, RF dropouts, or external forced disconnects.

## Observed stuck states this addresses

This change helps with the following failure modes observed in production:

| Stuck State | How this helps |
|---|---|
| **Stale BlueZ cache** — device not connected, but BlueZ has a stale cache entry from a previous session causing reconnect failures | `RemoveDevice` clears the stale entry, forcing clean re-discovery. **Primary fix.** |
| **Phantom connection (simple)** — BlueZ reports `Connected=True` but no real radio link exists; `connect()` hangs on GATT discovery and times out | After the timeout, `RemoveDevice` clears the phantom D-Bus state so the next retry starts fresh. |
| **Unclean service exit** — previous service instance exited without disconnecting, new instance inherits stale state | After first connection failure, stale state is cleared before retry. |

### Stuck states this does NOT address (future PRs)

| Stuck State | Why | Future fix |
|---|---|---|
| Phantom with cached services (connect succeeds silently) | `connect()` returns without error on the phantom; cleanup only fires after failures | Post-connect validation callback |
| Dead HCI handle / pending LE Create Connection | Requires HCI-level commands (`hcitool`), not D-Bus `RemoveDevice` | Shell-tool diagnostic framework |
| Deeply corrupted BlueZ state | `RemoveDevice` itself fails/hangs | Adapter reset escalation |
| Zombie connection (silent radio death) | Connection appears healthy, no failure triggers cleanup | Notification watchdog |
| Empty GATT services after connect | `connect()` succeeds, cleanup doesn't fire | Post-connect validation callback |

## Implementation

A single insertion point in the retry loop's common error path (after all exception handlers, before the next iteration). Uses the existing `clear_cache()` function which:

- Is a no-op on non-Linux platforms
- Suppresses all exceptions internally (cannot break the retry loop)
- Only sends `RemoveDevice` for paths that exist in the services cache
- Returns a boolean indicating whether anything was cleared (used for debug logging)

## Test plan

- [x] `clear_cache` called after BleakError failure
- [x] `clear_cache` called after TimeoutError
- [x] `clear_cache` called after BrokenPipeError
- [x] `clear_cache` called after EOFError
- [x] `clear_cache` called after every failure (not just the first)
- [x] `clear_cache` NOT called when connection succeeds
- [x] All 60 tests pass
- [x] All pre-commit checks pass (black, isort, flake8, mypy, bandit)

Made with [Cursor](https://cursor.com)