### PR TITLE
feat: classify InProgress errors with cleanup-first retry strategy

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -119,6 +119,15 @@ TRANSIENT_ERRORS_LONG_BACKOFF = {
 TRANSIENT_ERRORS_MEDIUM_BACKOFF = {
     "ESP_GATT_CONN_TIMEOUT",
     "ESP_GATT_CONN_FAIL_ESTABLISH",
+    # org.bluez.Error.InProgress during Connect means BlueZ's dev->connect
+    # pointer is non-NULL — a previous D-Bus Connect call is still pending
+    # (crashed client, stuck HCI LE Create Connection, etc.).
+    # See bluez/src/device.c dev_connect() lines 2837-2838.
+    # establish_connection() always passes a BLEDevice with a D-Bus path,
+    # so bleak never calls StartDiscovery; InProgress here is always stale
+    # BlueZ state, not scan contention.
+    # Medium backoff gives time for clear_cache()/RemoveDevice to propagate.
+    "InProgress",
 }
 
 DEVICE_MISSING_ERRORS = {"org.freedesktop.DBus.Error.UnknownObject"}
@@ -324,9 +333,7 @@ async def _has_valid_services_in_cache(device: BLEDevice) -> bool:
 def calculate_backoff_time(exc: Exception) -> float:
     """Calculate the backoff time based on the exception."""
 
-    if isinstance(
-        exc, (BleakDBusError, EOFError, asyncio.TimeoutError, BrokenPipeError)
-    ):
+    if isinstance(exc, (EOFError, asyncio.TimeoutError, BrokenPipeError)):
         return BLEAK_DBUS_BACKOFF_TIME
     # If the adapter runs out of slots can get a BleakDeviceNotFoundError
     # since the device is no longer visible on the adapter. Almost none of
@@ -345,6 +352,8 @@ def calculate_backoff_time(exc: Exception) -> float:
             return BLEAK_TRANSIENT_LONG_BACKOFF_TIME
         if any(error in bleak_error for error in TRANSIENT_ERRORS):
             return BLEAK_TRANSIENT_BACKOFF_TIME
+        if isinstance(exc, BleakDBusError):
+            return BLEAK_DBUS_BACKOFF_TIME
         if NORMAL_DISCONNECT in bleak_error:
             return BLEAK_DISCONNECTED_BACKOFF_TIME
     return BLEAK_BACKOFF_TIME
@@ -442,6 +451,7 @@ async def establish_connection(
 
     debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
     rssi: int | None = None
+    inprogress_cleared = False
     if IS_LINUX and (devices := await get_connected_devices(device)):
         # Bleak 0.17 will handle already connected devices for us so
         # if we are already connected we swap the device to the connected
@@ -557,21 +567,50 @@ async def establish_connection(
             _raise_if_needed(name, device.address, exc)
         except BLEAK_EXCEPTIONS as exc:
             bleak_error = str(exc)
+            is_inprogress = "InProgress" in bleak_error
             # BleakDeviceNotFoundError can mean that the adapter has run out of
             # connection slots.
             device_missing = isinstance(
                 exc, (BleakNotFoundError, BleakDeviceNotFoundError)
             )
-            if device_missing or any(
-                error in bleak_error for error in TRANSIENT_ERRORS
+            did_inprogress_cleanup = False
+            if is_inprogress and not inprogress_cleared:
+                # First InProgress: BlueZ's dev->connect is non-NULL from
+                # a stale/crashed D-Bus client.  RemoveDevice (via
+                # clear_cache) destroys the device object, clearing the
+                # pending state and any stuck HCI LE Create Connection.
+                connect_errors += 1
+                inprogress_cleared = True
+                did_inprogress_cleanup = True
+                if debug_enabled:
+                    _LOGGER.debug(
+                        "%s - %s: InProgress — closing stale connections"
+                        " and clearing cache (attempt: %s, last rssi: %s)",
+                        name,
+                        device.address,
+                        attempt,
+                        rssi,
+                    )
+                await close_stale_connections(device)
+                await clear_cache(device.address)
+            elif (
+                is_inprogress
+                or device_missing
+                or any(error in bleak_error for error in TRANSIENT_ERRORS)
             ):
+                # Second+ InProgress after RemoveDevice is unlikely
+                # (the recreated device object should have fresh state),
+                # but treat as transient safety-net in case another D-Bus
+                # client races or the device object hasn't settled yet.
+                # Other transient errors also go here.
                 transient_errors += 1
             else:
                 connect_errors += 1
             backoff_time = calculate_backoff_time(exc)
-            if debug_enabled:
+            if debug_enabled and not did_inprogress_cleanup:
                 _LOGGER.debug(
-                    "%s - %s: Failed to connect: %s, device_missing: %s, backing off: %s (attempt: %s, last rssi: %s)",
+                    "%s - %s: Failed to connect: %s, device_missing: %s,"
+                    " backing off: %s (attempt: %s, last rssi: %s)",
                     name,
                     device.address,
                     bleak_error,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -584,6 +584,136 @@ async def test_establish_connection_has_transient_error_had_advice():
 
 
 @pytest.mark.asyncio
+async def test_establish_connection_inprogress_first_cleans_up():
+    """First InProgress closes stale connections, clears cache, retries.
+
+    The first InProgress during connect is treated as stale/phantom state.
+    Close existing connections, clear the cache, and retry.  If cleanup
+    resolves it, the second attempt succeeds.
+    """
+    attempts = 0
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise BleakDBusError("org.bluez.Error.InProgress", ["In Progress"])
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch(
+            "bleak_retry_connector.close_stale_connections", new_callable=AsyncMock
+        ) as mock_close,
+        patch(
+            "bleak_retry_connector.clear_cache",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_clear,
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+    ):
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    assert attempts == 2
+    mock_close.assert_called_once()
+    mock_clear.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_inprogress_second_is_transient():
+    """Second+ InProgress after cleanup is treated as transient.
+
+    After the first InProgress triggers RemoveDevice, subsequent InProgress
+    errors are unlikely but handled as a transient safety-net (another D-Bus
+    client racing, device object not yet settled, etc.).
+    Retried up to MAX_TRANSIENT_ERRORS times after the initial cleanup.
+    """
+    attempts = 0
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            # First InProgress: cleanup (connect_error=1)
+            # Attempts 2..N: transient InProgress
+            # Succeed on attempt N+1
+            if attempts < MAX_TRANSIENT_ERRORS + 1:
+                raise BleakDBusError("org.bluez.Error.InProgress", ["In Progress"])
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch(
+            "bleak_retry_connector.close_stale_connections", new_callable=AsyncMock
+        ) as mock_close,
+        patch(
+            "bleak_retry_connector.clear_cache",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+    ):
+        client = await establish_connection(FakeBleakClient, MagicMock(), "test")
+
+    assert isinstance(client, FakeBleakClient)
+    # 1 cleanup attempt + 9 transient attempts = 10, succeeds on 11th
+    assert attempts == MAX_TRANSIENT_ERRORS + 1
+    # close_stale_connections only called on first InProgress
+    mock_close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_inprogress_exhaustion_aborts():
+    """InProgress that never clears produces BleakAbortedError with advice."""
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            raise BleakDBusError("org.bluez.Error.InProgress", ["In Progress"])
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch("bleak_retry_connector.close_stale_connections", new_callable=AsyncMock),
+        patch(
+            "bleak_retry_connector.clear_cache",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+    ):
+        try:
+            await establish_connection(
+                FakeBleakClient,
+                BLEDevice(
+                    "aa:bb:cc:dd:ee:ff",
+                    "name",
+                    {"path": "/org/bluez/hci2/dev_FA_23_9D_AA_45_46"},
+                ),
+                "test",
+            )
+        except BleakError as e:
+            exc = e
+
+    assert isinstance(exc, BleakAbortedError)
+    assert "InProgress" in str(exc)
+    assert "Interference/range" in str(exc)
+
+
+@pytest.mark.asyncio
 async def test_establish_connection_out_of_slots_advice():
     class FakeBleakClient(BleakClient):
         def __init__(self, *args, **kwargs):
@@ -1760,6 +1890,12 @@ def test_calculate_backoff_time():
     assert (
         calculate_backoff_time(BleakError("ESP_GATT_CONN_CONN_CANCEL"))
         == BLEAK_OUT_OF_SLOTS_BACKOFF_TIME
+    )
+    assert (
+        calculate_backoff_time(
+            BleakDBusError("org.bluez.Error.InProgress", ["In Progress"])
+        )
+        == BLEAK_TRANSIENT_MEDIUM_BACKOFF_TIME
     )
 
 


### PR DESCRIPTION
## Summary

`org.bluez.Error.InProgress` during `Connect` means BlueZ's `dev->connect` pointer is non-NULL — a previous D-Bus `Connect` call is still pending (crashed client, stuck HCI `LE Create Connection`, etc.). Since `establish_connection()` always passes a `BLEDevice` with a D-Bus path, bleak never calls `StartDiscovery`; `InProgress` here is always stale BlueZ state, not scan contention.

### What changed

- **Add `InProgress` to `TRANSIENT_ERRORS_MEDIUM_BACKOFF`** — assigns a 0.5s backoff (instead of the generic 0.25s D-Bus backoff) to give `RemoveDevice` time to propagate
- **Fix `calculate_backoff_time` ordering** — `BleakDBusError` was previously caught early as a generic D-Bus error, preventing `InProgress` (and other string-matched errors) from getting their specific backoff times. Now string-pattern matching runs first, with generic `BleakDBusError` as a fallback
- **Implement "cleanup once, then be patient" strategy** in `establish_connection`:
  - **First `InProgress`:** Call `close_stale_connections()` + `clear_cache()`/`RemoveDevice` across all adapters (hci0–hci8 via `_get_possible_paths()`), counted as a connect error (max 4 total)
  - **Subsequent `InProgress`:** Treated as transient safety-net (max 9 attempts) in case another D-Bus client races or the device object hasn't settled yet
- **Dedicated debug logging** for the first `InProgress` cleanup, distinguishing it from generic retry logging

### Stuck states this addresses

Based on field testing with multiple BLE services on Victron Cerbo GX / Venus OS:

| Impact | Stuck State | Description |
|--------|------------|-------------|
| **Direct fix** | State 3: Pending LE Create Connection | Stale `dev->connect` from crashed client or stuck HCI command. First `InProgress` triggers `RemoveDevice` which destroys the device object, clearing the pending state. This is the primary target of the PR. |
| **Significant help** | State 10: InProgress Dominance (All Adapters Stuck) | `close_stale_connections()` + `clear_cache()` operate across all adapters (hci0–hci8) via `_get_possible_paths()`, so a single `InProgress` event cleans up the device on every adapter. |
| **Helps** | State 14: Service Didn't Clean Up on Exit | Same mechanism — stale `dev->connect` left by a previous service instance is cleared by `RemoveDevice`. |
| **Partial help** | State 18: Multi-Service Adapter Saturation | Clears the "connect-phase" `InProgress` variant across all adapters, but doesn't resolve underlying resource exhaustion from other services. |
| **Marginal** | State 12: Deeply Corrupted BlueZ State | `RemoveDevice` across all adapters may clear some corruption, but deep corruption typically requires `bluetoothd` restart. |

### BlueZ source references

- `bluez/src/device.c` `dev_connect()` lines 2837–2838: `InProgress` is raised when `dev->connect` (pending D-Bus Connect request) is non-NULL
- `bluez/src/device.c` `device_connect_le()` line 6578: `Connect` ultimately issues HCI `LE Create Connection`
- `bleak/bleak/backends/bluezdbus/client.py`: When `BLEDevice` has a D-Bus path (which `establish_connection` always provides), bleak skips `StartDiscovery` entirely

## Test plan

- [x] New test: first `InProgress` triggers `close_stale_connections` + `clear_cache`, then retries successfully
- [x] New test: second+ `InProgress` after cleanup is treated as transient (up to `MAX_TRANSIENT_ERRORS` retries)
- [x] New test: persistent `InProgress` exhaustion produces `BleakAbortedError` with actionable advice
- [x] New test: `calculate_backoff_time` returns `BLEAK_TRANSIENT_MEDIUM_BACKOFF_TIME` for `InProgress`
- [x] All 48 existing tests continue to pass
- [x] `pre-commit` hooks pass (black, flake8, isort, mypy)

Made with [Cursor](https://cursor.com)