### PR TITLE
feat: enhance wait_for_disconnect() with phantom cleanup on timeout

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -495,7 +495,7 @@ async def establish_connection(
                     rssi,
                 )
             backoff_time = calculate_backoff_time(exc)
-            await wait_for_disconnect(device, backoff_time)
+            await wait_for_disconnect(device, backoff_time, validate_hci=True)
             _raise_if_needed(name, device.address, exc)
         except KeyError as exc:
             # Likely: KeyError: 'org.bluez.GattService1' from bleak
@@ -516,7 +516,7 @@ async def establish_connection(
                 await client.clear_cache()
                 await client.disconnect()
                 backoff_time = calculate_backoff_time(exc)
-                await wait_for_disconnect(device, backoff_time)
+                await wait_for_disconnect(device, backoff_time, validate_hci=True)
             _raise_if_needed(name, device.address, exc)
         except BrokenPipeError as exc:
             # BrokenPipeError is raised by dbus-next when the device disconnects
@@ -553,7 +553,7 @@ async def establish_connection(
                     attempt,
                     rssi,
                 )
-            await wait_for_disconnect(device, backoff_time)
+            await wait_for_disconnect(device, backoff_time, validate_hci=True)
             _raise_if_needed(name, device.address, exc)
         except BLEAK_EXCEPTIONS as exc:
             bleak_error = str(exc)
@@ -580,7 +580,7 @@ async def establish_connection(
                     attempt,
                     rssi,
                 )
-            await wait_for_disconnect(device, backoff_time)
+            await wait_for_disconnect(device, backoff_time, validate_hci=True)
             _raise_if_needed(name, device.address, exc)
         else:
             return client

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -385,7 +385,30 @@ async def wait_for_device_to_reappear(device: BLEDevice, wait_timeout: float) ->
     return False
 
 
-async def wait_for_disconnect(device: BLEDevice, min_wait_time: float) -> None:
+async def _is_device_connected(device_path: str) -> bool:
+    """Check if BlueZ still reports the device as Connected via D-Bus.
+
+    Returns ``False`` if the properties cannot be read (e.g. no manager)
+    or the device path is not in the properties tree.
+    """
+    properties = await _get_properties()
+    if properties is None:
+        return False
+    for path in _get_possible_paths(device_path):
+        if (
+            path in properties
+            and defs.DEVICE_INTERFACE in properties[path]
+            and properties[path][defs.DEVICE_INTERFACE].get("Connected")
+        ):
+            return True
+    return False
+
+
+async def wait_for_disconnect(
+    device: BLEDevice,
+    min_wait_time: float,
+    validate_hci: bool = False,
+) -> None:
     """Wait for the device to disconnect.
 
     After a connection failure, the device may not have
@@ -393,6 +416,13 @@ async def wait_for_disconnect(device: BLEDevice, min_wait_time: float) -> None:
 
     If we do not wait, we may end up connecting to the
     same device again before it has had time to disconnect.
+
+    When *validate_hci* is ``True`` and the disconnect wait times out,
+    the function checks whether BlueZ still reports the device as
+    ``Connected``.  If it does, this indicates a phantom or stuck
+    connection -- the D-Bus state is stale.  In that case
+    ``clear_cache()`` is called to force-remove the device from BlueZ,
+    breaking the phantom cycle before the next connection attempt.
     """
     if (
         not IS_LINUX
@@ -423,6 +453,21 @@ async def wait_for_disconnect(device: BLEDevice, min_wait_time: float) -> None:
         )
         if min_wait_time and waited < min_wait_time:
             await asyncio.sleep(min_wait_time - waited)
+    except TimeoutError:
+        _LOGGER.debug(
+            "%s - %s: Timed out waiting for disconnect at %s",
+            device.name,
+            device.address,
+            device_path,
+        )
+        if validate_hci and await _is_device_connected(device_path):
+            _LOGGER.warning(
+                "%s - %s: Device still Connected after disconnect timeout"
+                " — clearing stale BlueZ state (phantom likely)",
+                device.name,
+                device.address,
+            )
+            await clear_cache(device.address)
     except (BleakError, KeyError) as ex:
         # Device was removed from bus
         #

--- a/tests/test_bluez.py
+++ b/tests/test_bluez.py
@@ -15,11 +15,13 @@ from bleak_retry_connector import (
     device_source,
 )
 from bleak_retry_connector.bluez import (
+    _is_device_connected,
     adapter_path_from_device_path,
     ble_device_from_properties,
     path_from_ble_device,
     stop_discovery,
     wait_for_device_to_reappear,
+    wait_for_disconnect,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -737,3 +739,212 @@ async def test_stop_discovery_no_manager(
 
     await stop_discovery("hci0")
     assert "Failed to stop discovery" in caplog.text
+
+
+async def test_is_device_connected_true(mock_linux):
+    """_is_device_connected returns True when BlueZ reports Connected."""
+
+    properties: dict[str, dict[str, dict[str, Any]]] = {
+        "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF": {
+            defs.DEVICE_INTERFACE: {
+                "Address": "AA:BB:CC:DD:EE:FF",
+                "Connected": True,
+            }
+        }
+    }
+
+    class FakeBluezManager:
+        _properties = properties
+
+    bleak_retry_connector.bleak_manager.get_global_bluez_manager = AsyncMock(
+        return_value=FakeBluezManager()
+    )
+
+    result = await _is_device_connected("/org/bluez/hciX/dev_AA_BB_CC_DD_EE_FF")
+    assert result is True
+
+
+async def test_is_device_connected_false(mock_linux):
+    """_is_device_connected returns False when device is not Connected."""
+
+    properties: dict[str, dict[str, dict[str, Any]]] = {
+        "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF": {
+            defs.DEVICE_INTERFACE: {
+                "Address": "AA:BB:CC:DD:EE:FF",
+                "Connected": False,
+            }
+        }
+    }
+
+    class FakeBluezManager:
+        _properties = properties
+
+    bleak_retry_connector.bleak_manager.get_global_bluez_manager = AsyncMock(
+        return_value=FakeBluezManager()
+    )
+
+    result = await _is_device_connected("/org/bluez/hciX/dev_AA_BB_CC_DD_EE_FF")
+    assert result is False
+
+
+async def test_is_device_connected_no_manager(mock_linux):
+    """_is_device_connected returns False when there is no manager."""
+
+    bleak_retry_connector.bleak_manager.get_global_bluez_manager = AsyncMock(
+        return_value=None
+    )
+
+    result = await _is_device_connected("/org/bluez/hciX/dev_AA_BB_CC_DD_EE_FF")
+    assert result is False
+
+
+async def test_wait_for_disconnect_validate_hci_clears_phantom(
+    mock_linux: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When validate_hci=True and disconnect times out with device still
+    Connected, clear_cache should be called to clean up the phantom."""
+
+    properties: dict[str, dict[str, dict[str, Any]]] = {
+        "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF": {
+            defs.DEVICE_INTERFACE: {
+                "Address": "AA:BB:CC:DD:EE:FF",
+                "Alias": "test-device",
+                "Connected": True,
+            }
+        }
+    }
+
+    class FakeBluezManager:
+        _properties = properties
+
+        async def _wait_condition(self, path, prop, value):
+            raise TimeoutError("disconnect timeout")
+
+    manager = FakeBluezManager()
+
+    bleak_retry_connector.bleak_manager.get_global_bluez_manager = AsyncMock(
+        return_value=manager
+    )
+
+    device = BLEDevice(
+        "AA:BB:CC:DD:EE:FF",
+        "test-device",
+        {"path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"},
+    )
+
+    with patch(
+        "bleak_retry_connector.bluez.clear_cache",
+        new_callable=AsyncMock,
+    ) as mock_clear_cache:
+        await wait_for_disconnect(device, 0.0, validate_hci=True)
+
+    mock_clear_cache.assert_awaited_once_with("AA:BB:CC:DD:EE:FF")
+    assert "still Connected after disconnect timeout" in caplog.text
+    assert "phantom likely" in caplog.text
+
+
+async def test_wait_for_disconnect_validate_hci_no_clear_when_disconnected(
+    mock_linux: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When validate_hci=True but the device is no longer Connected after
+    the timeout, clear_cache should NOT be called."""
+
+    properties: dict[str, dict[str, dict[str, Any]]] = {
+        "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF": {
+            defs.DEVICE_INTERFACE: {
+                "Address": "AA:BB:CC:DD:EE:FF",
+                "Alias": "test-device",
+                "Connected": False,
+            }
+        }
+    }
+
+    class FakeBluezManager:
+        _properties = properties
+
+        async def _wait_condition(self, path, prop, value):
+            raise TimeoutError("disconnect timeout")
+
+    manager = FakeBluezManager()
+
+    bleak_retry_connector.bleak_manager.get_global_bluez_manager = AsyncMock(
+        return_value=manager
+    )
+
+    device = BLEDevice(
+        "AA:BB:CC:DD:EE:FF",
+        "test-device",
+        {"path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"},
+    )
+
+    with patch(
+        "bleak_retry_connector.bluez.clear_cache",
+        new_callable=AsyncMock,
+    ) as mock_clear_cache:
+        await wait_for_disconnect(device, 0.0, validate_hci=True)
+
+    mock_clear_cache.assert_not_awaited()
+
+
+async def test_wait_for_disconnect_no_validate_hci_on_timeout(
+    mock_linux: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When validate_hci=False (default), disconnect timeout does NOT
+    trigger clear_cache even if device is still Connected."""
+
+    properties: dict[str, dict[str, dict[str, Any]]] = {
+        "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF": {
+            defs.DEVICE_INTERFACE: {
+                "Address": "AA:BB:CC:DD:EE:FF",
+                "Alias": "test-device",
+                "Connected": True,
+            }
+        }
+    }
+
+    class FakeBluezManager:
+        _properties = properties
+
+        async def _wait_condition(self, path, prop, value):
+            raise TimeoutError("disconnect timeout")
+
+    manager = FakeBluezManager()
+
+    bleak_retry_connector.bleak_manager.get_global_bluez_manager = AsyncMock(
+        return_value=manager
+    )
+
+    device = BLEDevice(
+        "AA:BB:CC:DD:EE:FF",
+        "test-device",
+        {"path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"},
+    )
+
+    with patch(
+        "bleak_retry_connector.bluez.clear_cache",
+        new_callable=AsyncMock,
+    ) as mock_clear_cache:
+        await wait_for_disconnect(device, 0.0, validate_hci=False)
+
+    mock_clear_cache.assert_not_awaited()
+
+
+async def test_wait_for_disconnect_validate_hci_non_linux() -> None:
+    """On non-Linux, validate_hci has no effect (early return to sleep)."""
+
+    device = BLEDevice(
+        "AA:BB:CC:DD:EE:FF",
+        "test-device",
+        {"path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"},
+    )
+
+    with (
+        patch.object(bleak_retry_connector.bluez, "IS_LINUX", False),
+        patch(
+            "bleak_retry_connector.bluez.clear_cache",
+            new_callable=AsyncMock,
+        ) as mock_clear_cache,
+    ):
+        await wait_for_disconnect(device, 0.0, validate_hci=True)
+
+    mock_clear_cache.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Adds `validate_hci: bool = False` parameter to `wait_for_disconnect()` that detects and cleans up phantom connections when the disconnect wait times out
- When enabled: checks if BlueZ still reports `Connected=True` after the timeout, and if so calls `clear_cache()` to force-remove the stale device
- `establish_connection()` now passes `validate_hci=True` to all its `wait_for_disconnect()` calls, actively breaking the phantom cycle between retry attempts
- Adds `_is_device_connected()` helper that queries the BlueZ D-Bus properties tree across all adapter paths

## Problem

`wait_for_disconnect()` watches for the BlueZ `Connected` property to become `False`. In a phantom state (Stuck State 1), `Connected` never becomes `False` because BlueZ doesn't know the HCI transport is gone. The function times out after `DISCONNECT_TIMEOUT` (5s) and silently returns, but the phantom persists.

On the next retry, `establish_connection()` either:
- Adopts the phantom via `get_connected_devices()` and returns a non-functional client
- Tries to connect and gets stuck again because BlueZ believes it's already connected

This creates a permanent loop where the service appears running but publishes stale data.

## How it works

When `validate_hci=True` and `wait_for_disconnect()` times out:

1. **Check**: Query BlueZ D-Bus properties to see if the device is still reported as `Connected=True` on any adapter path (`hci0`-`hci8`)
2. **Clean**: If still Connected, this is a phantom — call `clear_cache()` which sends `RemoveDevice` to BlueZ, forcing it to drop the stale D-Bus state
3. **Log**: Emit a warning so the phantom is visible in logs

When `validate_hci=False` (default), behavior is unchanged from before this PR.

## Stuck states this addresses

| State | Name | How this PR helps |
|-------|------|-------------------|
| **State 1** | Phantom Connection (No HCI Handle) | **Direct fix.** When the disconnect wait times out and BlueZ still reports `Connected=True` with no underlying HCI transport, `clear_cache()` force-removes the phantom before the next retry attempt |
| **State 2** | Dead HCI Handle (Transport Dead) | **Partial fix.** A dead handle will also show `Connected=True` after timeout; `clear_cache()` / `RemoveDevice` cleans up the stale BlueZ state (though full handle-level cleanup requires `hcitool ledc` from a future PR) |
| **State 8** | `BleakClient.disconnect()` Hang | **Indirect benefit.** By cleaning phantoms between retries, fewer disconnect calls attempt to operate on dead transports, reducing the probability of hangs |

## Test plan

- [x] `test_is_device_connected_true` — returns True when BlueZ reports Connected
- [x] `test_is_device_connected_false` — returns False when not Connected
- [x] `test_is_device_connected_no_manager` — returns False when no BlueZ manager
- [x] `test_wait_for_disconnect_validate_hci_clears_phantom` — calls `clear_cache()` when device still Connected after timeout
- [x] `test_wait_for_disconnect_validate_hci_no_clear_when_disconnected` — does NOT call `clear_cache()` when device properly disconnected
- [x] `test_wait_for_disconnect_no_validate_hci_on_timeout` — default `validate_hci=False` does not trigger cleanup
- [x] `test_wait_for_disconnect_validate_hci_non_linux` — no effect on non-Linux platforms
- [x] All 61 existing tests pass
- [x] All pre-commit hooks pass (black, flake8, mypy, bandit, isort, etc.)

Made with [Cursor](https://cursor.com)