### PR TITLE
feat: add per-adapter cross-process file locking for BLE serialization

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -29,7 +29,8 @@ from .bluez import (  # noqa: F401
     wait_for_device_to_reappear,
     wait_for_disconnect,
 )
-from .const import IS_LINUX, NO_RSSI_VALUE, RSSI_SWITCH_THRESHOLD
+from .const import IS_LINUX, NO_RSSI_VALUE, RSSI_SWITCH_THRESHOLD, LockConfig
+from .lock import acquire_lock, release_lock
 from .util import asyncio_timeout
 
 DISCONNECT_TIMEOUT = 5
@@ -78,6 +79,7 @@ __all__ = [
     "BLEAK_RETRY_EXCEPTIONS",
     "RSSI_SWITCH_THRESHOLD",
     "NO_RSSI_VALUE",
+    "LockConfig",
 ]
 
 
@@ -405,9 +407,24 @@ async def establish_connection(
     ble_device_callback: Callable[[], BLEDevice] | None = None,
     use_services_cache: bool = True,
     pair: bool = False,
+    lock_config: LockConfig | None = None,
+    in_process_semaphore: asyncio.Semaphore | None = None,
     **kwargs: Any,
 ) -> AnyBleakClient:
-    """Establish a connection to the device."""
+    """Establish a connection to the device.
+
+    When *lock_config* is provided with ``enabled=True``, a per-adapter
+    file lock (``fcntl.flock``) is held during each connection attempt
+    to serialize BLE operations across processes sharing the same
+    adapter.  The lock is released after each attempt so other processes
+    can interleave between retries.
+
+    When *in_process_semaphore* is provided, it is acquired before each
+    connection attempt and released afterward.  This serializes BLE
+    operations within the same process (useful when multiple asyncio
+    tasks share an adapter).  Both parameters can be used together for
+    full cross-process + in-process serialization.
+    """
     timeouts = 0
     connect_errors = 0
     transient_errors = 0
@@ -465,6 +482,18 @@ async def establish_connection(
                 device.address,
                 attempt,
             )
+
+        # Acquire per-adapter file lock and/or in-process semaphore
+        # before the connection attempt.  Released in the finally block
+        # so other processes/tasks can interleave between retries.
+        lock_fd: int | None = None
+        semaphore_acquired = False
+        if lock_config is not None:
+            adapter = kwargs.get("adapter")
+            lock_fd = await acquire_lock(lock_config, adapter)
+        if in_process_semaphore is not None:
+            await in_process_semaphore.acquire()
+            semaphore_acquired = True
 
         try:
             async with asyncio_timeout(BLEAK_SAFETY_TIMEOUT):
@@ -584,6 +613,10 @@ async def establish_connection(
             _raise_if_needed(name, device.address, exc)
         else:
             return client
+        finally:
+            release_lock(lock_fd)
+            if semaphore_acquired and in_process_semaphore is not None:
+                in_process_semaphore.release()
         # Ensure the disconnect callback
         # has a chance to run before we try to reconnect
         await asyncio.sleep(0)

--- a/src/bleak_retry_connector/const.py
+++ b/src/bleak_retry_connector/const.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import platform
+from dataclasses import dataclass
 
 IS_LINUX = platform.system() == "Linux"
 NO_RSSI_VALUE = -127
@@ -8,3 +9,43 @@ RSSI_SWITCH_THRESHOLD = 5
 DISCONNECT_TIMEOUT = 5
 REAPPEAR_WAIT_INTERVAL = 0.5
 DBUS_CONNECT_TIMEOUT = 8.5
+
+
+@dataclass
+class LockConfig:
+    """Configuration for cross-process BLE serialization locks.
+
+    On multi-service systems (e.g. Venus OS / Cerbo GX) several processes
+    may compete for the same BLE adapter, causing ``InProgress`` errors
+    on ~40 %% of connection attempts.  A per-adapter file lock serializes
+    these operations so only one process uses a given adapter at a time.
+
+    All services sharing adapters on the same host **must** use the same
+    *lock_dir* and *lock_template* to coordinate.
+
+    Parameters
+    ----------
+    enabled:
+        Whether cross-process locking is active.
+    lock_dir:
+        Directory for lock files.  Must be writable by all participating
+        services.
+    lock_template:
+        Template string with an ``{adapter}`` placeholder, e.g.
+        ``"bleak-retry-connector-{adapter}.lock"``.
+    lock_timeout:
+        Maximum seconds to wait for lock acquisition.  If exceeded, the
+        connection attempt proceeds without the lock (graceful
+        degradation) to prevent deadlock when a lock holder crashes.
+    """
+
+    enabled: bool = False
+    lock_dir: str = "/tmp"  # nosec
+    lock_template: str = "bleak-retry-connector-{adapter}.lock"
+    lock_timeout: float = 15.0
+
+    def path_for_adapter(self, adapter: str | None) -> str:
+        """Return the full lock file path for a given adapter."""
+        name = adapter or "default"
+        filename = self.lock_template.format(adapter=name)
+        return f"{self.lock_dir}/{filename}"

--- a/src/bleak_retry_connector/const.py
+++ b/src/bleak_retry_connector/const.py
@@ -28,8 +28,10 @@ class LockConfig:
     enabled:
         Whether cross-process locking is active.
     lock_dir:
-        Directory for lock files.  Must be writable by all participating
-        services.
+        Directory for lock files.  Defaults to ``/run`` which is the
+        standard location for runtime state files — cleared on reboot
+        so stale locks cannot survive reboots.  Must be writable by all
+        participating services.
     lock_template:
         Template string with an ``{adapter}`` placeholder, e.g.
         ``"bleak-retry-connector-{adapter}.lock"``.
@@ -40,7 +42,7 @@ class LockConfig:
     """
 
     enabled: bool = False
-    lock_dir: str = "/tmp"  # nosec
+    lock_dir: str = "/run"
     lock_template: str = "bleak-retry-connector-{adapter}.lock"
     lock_timeout: float = 15.0
 

--- a/src/bleak_retry_connector/lock.py
+++ b/src/bleak_retry_connector/lock.py
@@ -1,0 +1,97 @@
+"""Cross-process file locking for BLE adapter serialization.
+
+On multi-service systems several processes may compete for the same BLE
+adapter, causing ``InProgress`` errors.  This module provides async-safe
+``fcntl.flock`` helpers that serialize BLE operations per adapter without
+blocking the asyncio event loop.
+
+The lock is **non-blocking** (``LOCK_NB``).  If the lock is held by
+another process, the caller retries with ``asyncio.sleep()`` between
+attempts.  If acquisition times out, the caller proceeds without the
+lock (graceful degradation).
+
+``fcntl.flock`` is automatically released when the file descriptor is
+closed — including process exit — so a crashed process cannot hold the
+lock permanently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .const import LockConfig
+
+try:
+    import fcntl
+
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
+
+_LOGGER = logging.getLogger(__name__)
+
+_LOCK_RETRY_INTERVAL = 0.25
+
+
+async def acquire_lock(
+    lock_config: LockConfig,
+    adapter: str | None,
+) -> int | None:
+    """Acquire an exclusive file lock for the given adapter.
+
+    Returns the file descriptor on success, or ``None`` if the lock
+    could not be acquired within *lock_config.lock_timeout* seconds.
+    When ``None`` is returned the caller should proceed without the
+    lock (graceful degradation).
+    """
+    if not _HAS_FCNTL or not lock_config.enabled:
+        return None
+
+    lock_path = lock_config.path_for_adapter(adapter)
+    elapsed = 0.0
+
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o666)
+    except OSError:
+        _LOGGER.debug(
+            "Failed to open lock file %s, proceeding without lock",
+            lock_path,
+            exc_info=True,
+        )
+        return None
+
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            _LOGGER.debug("Acquired BLE lock %s (adapter=%s)", lock_path, adapter)
+            return fd
+        except OSError:
+            elapsed += _LOCK_RETRY_INTERVAL
+            if elapsed >= lock_config.lock_timeout:
+                _LOGGER.warning(
+                    "Timed out waiting for BLE lock %s after %.1f s"
+                    " — proceeding without lock",
+                    lock_path,
+                    elapsed,
+                )
+                os.close(fd)
+                return None
+            await asyncio.sleep(_LOCK_RETRY_INTERVAL)
+
+
+def release_lock(fd: int | None) -> None:
+    """Release a previously acquired file lock.
+
+    Safe to call with ``None`` (no-op).
+    """
+    if fd is None:
+        return
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    except OSError:
+        _LOGGER.debug("Failed to release BLE lock", exc_info=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -584,6 +584,151 @@ async def test_establish_connection_has_transient_error_had_advice():
 
 
 @pytest.mark.asyncio
+async def test_establish_connection_with_lock_config():
+    """Lock is acquired and released around connection attempts."""
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    from bleak_retry_connector import LockConfig
+
+    with (
+        patch(
+            "bleak_retry_connector.acquire_lock", new_callable=AsyncMock
+        ) as mock_acquire,
+        patch("bleak_retry_connector.release_lock") as mock_release,
+    ):
+        mock_acquire.return_value = 42
+
+        config = LockConfig(enabled=True)
+        client = await establish_connection(
+            FakeBleakClient,
+            MagicMock(),
+            "test",
+            lock_config=config,
+        )
+
+    assert isinstance(client, FakeBleakClient)
+    mock_acquire.assert_awaited_once()
+    mock_release.assert_called_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_with_semaphore():
+    """In-process semaphore is acquired and released."""
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    import asyncio
+
+    sem = asyncio.Semaphore(1)
+
+    client = await establish_connection(
+        FakeBleakClient,
+        MagicMock(),
+        "test",
+        in_process_semaphore=sem,
+    )
+
+    assert isinstance(client, FakeBleakClient)
+    # Semaphore should be released (value back to 1)
+    assert not sem.locked()
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_lock_released_on_failure():
+    """Lock and semaphore are released even when connection fails."""
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            raise BleakError("connection failed")
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    import asyncio
+
+    from bleak_retry_connector import LockConfig
+
+    sem = asyncio.Semaphore(1)
+
+    with (
+        patch(
+            "bleak_retry_connector.acquire_lock", new_callable=AsyncMock
+        ) as mock_acquire,
+        patch("bleak_retry_connector.release_lock") as mock_release,
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+    ):
+        mock_acquire.return_value = 42
+
+        config = LockConfig(enabled=True)
+        try:
+            await establish_connection(
+                FakeBleakClient,
+                BLEDevice(
+                    "aa:bb:cc:dd:ee:ff",
+                    "name",
+                    {"path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"},
+                ),
+                "test",
+                lock_config=config,
+                in_process_semaphore=sem,
+            )
+        except BleakError:
+            pass
+
+    # Lock should be released once per attempt (4 attempts by default)
+    assert mock_release.call_count == mock_acquire.await_count
+    # Semaphore should be released
+    assert not sem.locked()
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_no_lock_by_default():
+    """No lock is acquired when lock_config is not provided."""
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with patch(
+        "bleak_retry_connector.acquire_lock", new_callable=AsyncMock
+    ) as mock_acquire:
+        client = await establish_connection(
+            FakeBleakClient,
+            MagicMock(),
+            "test",
+        )
+
+    assert isinstance(client, FakeBleakClient)
+    mock_acquire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_establish_connection_out_of_slots_advice():
     class FakeBleakClient(BleakClient):
         def __init__(self, *args, **kwargs):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,116 @@
+"""Tests for cross-process file locking."""
+
+from __future__ import annotations
+
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from bleak_retry_connector.const import LockConfig
+from bleak_retry_connector.lock import acquire_lock, release_lock
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_lock_config_path_for_adapter():
+    """LockConfig generates correct paths for adapters."""
+    config = LockConfig(enabled=True, lock_dir="/tmp")
+    assert config.path_for_adapter("hci0") == ("/tmp/bleak-retry-connector-hci0.lock")
+    assert config.path_for_adapter("hci1") == ("/tmp/bleak-retry-connector-hci1.lock")
+    assert config.path_for_adapter(None) == ("/tmp/bleak-retry-connector-default.lock")
+
+
+async def test_lock_config_custom_template():
+    """LockConfig supports custom templates."""
+    config = LockConfig(
+        enabled=True,
+        lock_dir="/var/lock",
+        lock_template="my-service-{adapter}.lock",
+    )
+    assert config.path_for_adapter("hci0") == "/var/lock/my-service-hci0.lock"
+
+
+async def test_acquire_release_lock():
+    """Lock can be acquired and released."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = LockConfig(enabled=True, lock_dir=tmpdir)
+        fd = await acquire_lock(config, "hci0")
+        assert fd is not None
+        release_lock(fd)
+
+
+async def test_acquire_lock_disabled():
+    """Lock is not acquired when config is disabled."""
+    config = LockConfig(enabled=False)
+    fd = await acquire_lock(config, "hci0")
+    assert fd is None
+
+
+async def test_acquire_lock_no_fcntl():
+    """Lock is not acquired when fcntl is unavailable."""
+    config = LockConfig(enabled=True)
+    with patch("bleak_retry_connector.lock._HAS_FCNTL", False):
+        fd = await acquire_lock(config, "hci0")
+    assert fd is None
+
+
+async def test_release_lock_none():
+    """release_lock(None) is a safe no-op."""
+    release_lock(None)
+
+
+async def test_lock_contention_timeout():
+    """Second lock acquisition times out when first holds the lock."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = LockConfig(
+            enabled=True,
+            lock_dir=tmpdir,
+            lock_timeout=0.5,
+        )
+        fd1 = await acquire_lock(config, "hci0")
+        assert fd1 is not None
+
+        fd2 = await acquire_lock(config, "hci0")
+        assert fd2 is None
+
+        release_lock(fd1)
+
+
+async def test_lock_released_after_holder_closes():
+    """Lock can be re-acquired after previous holder releases."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = LockConfig(
+            enabled=True,
+            lock_dir=tmpdir,
+            lock_timeout=1.0,
+        )
+        fd1 = await acquire_lock(config, "hci0")
+        assert fd1 is not None
+        release_lock(fd1)
+
+        fd2 = await acquire_lock(config, "hci0")
+        assert fd2 is not None
+        release_lock(fd2)
+
+
+async def test_lock_per_adapter_independent():
+    """Locks for different adapters are independent."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = LockConfig(enabled=True, lock_dir=tmpdir)
+        fd_hci0 = await acquire_lock(config, "hci0")
+        fd_hci1 = await acquire_lock(config, "hci1")
+        assert fd_hci0 is not None
+        assert fd_hci1 is not None
+        release_lock(fd_hci0)
+        release_lock(fd_hci1)
+
+
+async def test_lock_bad_directory():
+    """Lock gracefully degrades if directory is not writable."""
+    config = LockConfig(
+        enabled=True,
+        lock_dir="/nonexistent/path/that/does/not/exist",
+    )
+    fd = await acquire_lock(config, "hci0")
+    assert fd is None


### PR DESCRIPTION
## Summary

- Adds `LockConfig` dataclass for configuring per-adapter file locks that serialize BLE operations across processes
- Adds `lock.py` module with async-safe `acquire_lock()` / `release_lock()` using non-blocking `fcntl.flock`
- Adds `lock_config` and `in_process_semaphore` parameters to `establish_connection()` for cross-process and in-process serialization
- Lock is acquired before each connection attempt and released in a `finally` block, allowing other processes to interleave between retries

## Problem

On multi-service systems (e.g. Venus OS / Cerbo GX), several processes compete for the same BLE adapter simultaneously:

| Service | BLE operations |
|---------|----------------|
| `dbus-serialbattery` (1 per BLE battery) | Scan + connect every ~60s |
| `dbus-power-watchdog` | Scan on discovery + persistent connect |
| `dbus-shyion-switch` | Scan on discovery + connect-on-demand |
| `dbus-ble-sensors` (Victron) | Continuous passive scan |
| `vesmart-server` (Victron) | Periodic GATT connect |

Without coordination, 3-5 processes compete for a single BlueZ adapter, producing `org.bluez.Error.InProgress` errors on ~40% of connection attempts.

## Design decisions

| Decision | Rationale |
|----------|-----------|
| **Per-adapter locks** (not global) | `hci0` and `hci1` are independent radios. A global lock unnecessarily serializes operations that could run in parallel on different adapters |
| **Opt-in** (`LockConfig(enabled=True)`) | Existing callers are unaffected; only multi-service deployments need this |
| **Non-blocking flock** (`LOCK_NB` + `asyncio.sleep` retry) | A blocking `LOCK_EX` would freeze the asyncio event loop |
| **Graceful degradation** on timeout | Proceeds without the lock after `lock_timeout` seconds to prevent deadlock if a lock holder crashes |
| **`fcntl.flock` auto-release** | Released automatically on fd close / process exit — crashed processes cannot hold the lock permanently |
| **`in_process_semaphore`** parameter | `fcntl.flock` is per-process, not per-thread. Multiple asyncio tasks in the same process need an `asyncio.Semaphore` for serialization. Both can be used together |
| **Lock released per attempt** | Lock is held only during `client.connect()`, not during backoff. Other processes can interleave between retry attempts |

## Stuck states this addresses

| State | Name | How this PR helps |
|-------|------|-------------------|
| **State 4** | Scan Collision (InProgress During Scan) | **Direct fix.** Per-adapter file lock prevents concurrent scans on the same adapter across processes |
| **State 10** | InProgress Dominance (All Adapters Stuck) | **Partial fix.** Serialization reduces the probability of all adapters being stuck simultaneously from concurrent operations |

## Usage

```python
from bleak_retry_connector import establish_connection, LockConfig

# Multi-process: per-adapter file lock
lock_config = LockConfig(enabled=True)

# Multi-task (same process): shared semaphore
import asyncio
semaphore = asyncio.Semaphore(1)

client = await establish_connection(
    BleakClient,
    device,
    "my-service",
    lock_config=lock_config,
    in_process_semaphore=semaphore,
)
```

## Test plan

- [x] `test_lock_config_path_for_adapter` — correct path generation per adapter
- [x] `test_lock_config_custom_template` — custom lock templates work
- [x] `test_acquire_release_lock` — basic acquire/release cycle
- [x] `test_acquire_lock_disabled` — no lock when config disabled
- [x] `test_acquire_lock_no_fcntl` — graceful degradation without fcntl
- [x] `test_release_lock_none` — safe no-op on None
- [x] `test_lock_contention_timeout` — second acquirer times out
- [x] `test_lock_released_after_holder_closes` — re-acquire after release
- [x] `test_lock_per_adapter_independent` — hci0 and hci1 locks are independent
- [x] `test_lock_bad_directory` — graceful degradation on missing directory
- [x] `test_establish_connection_with_lock_config` — lock acquired/released around connection
- [x] `test_establish_connection_with_semaphore` — semaphore acquired/released
- [x] `test_establish_connection_lock_released_on_failure` — lock+semaphore released on error
- [x] `test_establish_connection_no_lock_by_default` — no lock when not configured
- [x] All 68 existing tests pass
- [x] All pre-commit hooks pass (black, flake8, mypy, bandit, isort, etc.)

Made with [Cursor](https://cursor.com)