### PR TITLE
feat: adapter recovery escalation chain and tool capabilities

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -30,6 +30,17 @@ from .bluez import (  # noqa: F401
     wait_for_disconnect,
 )
 from .const import IS_LINUX, NO_RSSI_VALUE, RSSI_SWITCH_THRESHOLD
+from .recovery import (  # noqa: F401
+    PROFILE_BATTERY,
+    PROFILE_ON_DEMAND,
+    PROFILE_SENSOR,
+    TOOLS,
+    EscalationAction,
+    EscalationConfig,
+    EscalationPolicy,
+    ToolCapabilities,
+    reset_adapter,
+)
 from .util import asyncio_timeout
 
 DISCONNECT_TIMEOUT = 5
@@ -78,6 +89,15 @@ __all__ = [
     "BLEAK_RETRY_EXCEPTIONS",
     "RSSI_SWITCH_THRESHOLD",
     "NO_RSSI_VALUE",
+    "ToolCapabilities",
+    "TOOLS",
+    "EscalationAction",
+    "EscalationConfig",
+    "EscalationPolicy",
+    "PROFILE_BATTERY",
+    "PROFILE_SENSOR",
+    "PROFILE_ON_DEMAND",
+    "reset_adapter",
 ]
 
 

--- a/src/bleak_retry_connector/recovery.py
+++ b/src/bleak_retry_connector/recovery.py
@@ -1,0 +1,369 @@
+"""Adapter recovery and escalation chain for BLE connection failures.
+
+Provides a configurable escalation policy that tracks consecutive
+failures per adapter and recommends increasingly aggressive recovery
+actions.  The policy respects caller configuration — it never suggests
+an action the caller has disabled.
+
+Escalation levels (least to most disruptive)::
+
+    1. RETRY          — simple backoff retry
+    2. DIAGNOSE       — diagnose stuck state + targeted fix (future PR 1)
+    3. CLEAR_BLUEZ    — clear InProgress-dominant stale BlueZ state
+    4. ROTATE_ADAPTER — switch to a different adapter
+    5. RESET_ADAPTER  — hciconfig down/up (disrupts ALL connections)
+
+Also provides:
+- :class:`ToolCapabilities` for detecting available BLE shell tools
+- :func:`reset_adapter` as a standalone last-resort utility
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess  # nosec
+import time
+from dataclasses import dataclass
+from enum import Enum
+
+from .const import IS_LINUX
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tool capabilities — probed once at import
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolCapabilities:
+    """Detected system tool availability — probed once at import time.
+
+    All diagnostic and recovery code should check this object instead of
+    calling ``shutil.which()`` ad-hoc.
+    """
+
+    bluetoothctl: str | None = None
+    hcitool: str | None = None
+    hciconfig: str | None = None
+    rfkill: str | None = None
+
+    @property
+    def has_shell_tools(self) -> bool:
+        """True if the core diagnostic tools are available."""
+        return self.bluetoothctl is not None and self.hcitool is not None
+
+    @property
+    def can_reset_adapter(self) -> bool:
+        """True if adapter reset is possible."""
+        return self.hciconfig is not None
+
+    @property
+    def can_diagnose(self) -> bool:
+        """True if precise stuck-state diagnosis is possible."""
+        return self.has_shell_tools
+
+    @classmethod
+    def detect(cls) -> ToolCapabilities:
+        """Probe the system for available BLE tools.
+
+        Called once at module import.  Results are cached for the
+        lifetime of the process.
+        """
+        return cls(
+            bluetoothctl=shutil.which("bluetoothctl"),
+            hcitool=shutil.which("hcitool"),
+            hciconfig=shutil.which("hciconfig"),
+            rfkill=shutil.which("rfkill"),
+        )
+
+
+TOOLS = ToolCapabilities.detect()
+
+
+# ---------------------------------------------------------------------------
+# Escalation configuration
+# ---------------------------------------------------------------------------
+
+
+class EscalationAction(str, Enum):
+    """Actions the escalation policy can recommend."""
+
+    RETRY = "retry"
+    DIAGNOSE = "diagnose"
+    CLEAR_BLUEZ = "clear_bluez"
+    ROTATE_ADAPTER = "rotate"
+    RESET_ADAPTER = "reset"
+
+
+# Ordered from least to most disruptive
+_LEVELS = list(EscalationAction)
+
+
+@dataclass
+class EscalationConfig:
+    """Configuration for the recovery escalation chain.
+
+    Each escalation level can be individually enabled or disabled.
+    Thresholds control when each level triggers.
+
+    Parameters
+    ----------
+    diagnose_and_fix:
+        Enable stuck-state diagnosis + targeted fix.  Almost always
+        ``True``.
+    clear_bluez_on_inprogress_dominance:
+        Enable BlueZ state cleanup when ``InProgress`` errors dominate
+        all adapters.
+    rotate_adapter:
+        Enable adapter rotation on failure.  Requires multiple adapters.
+    reset_adapter:
+        Enable adapter reset as last resort.  **WARNING:** disrupts ALL
+        connections on the adapter.  Only enable if this service "owns"
+        the adapter or coordinates with others.  Default ``False``.
+    rotate_after:
+        Consecutive failures before rotating adapter.
+    clear_after:
+        Consecutive ``InProgress`` failures before BlueZ cleanup.
+    reset_after:
+        Consecutive failures before adapter reset.
+    reset_cooldown:
+        Minimum seconds between adapter resets.
+    max_escalation:
+        Hard ceiling on escalation.  Even if ``reset_adapter`` is
+        ``True``, setting ``max_escalation`` to
+        :attr:`EscalationAction.ROTATE_ADAPTER` prevents reset.
+    """
+
+    diagnose_and_fix: bool = True
+    clear_bluez_on_inprogress_dominance: bool = True
+    rotate_adapter: bool = True
+    reset_adapter: bool = False
+    rotate_after: int = 2
+    clear_after: int = 4
+    reset_after: int = 6
+    reset_cooldown: float = 300.0
+    max_escalation: EscalationAction = EscalationAction.RESET_ADAPTER
+
+
+# Pre-built profiles for common service types
+PROFILE_BATTERY = EscalationConfig(
+    reset_adapter=True,
+    reset_after=6,
+    reset_cooldown=300.0,
+)
+
+PROFILE_SENSOR = EscalationConfig(
+    reset_adapter=False,
+    max_escalation=EscalationAction.ROTATE_ADAPTER,
+)
+
+PROFILE_ON_DEMAND = EscalationConfig(
+    clear_bluez_on_inprogress_dominance=False,
+    reset_adapter=False,
+    rotate_after=1,
+    max_escalation=EscalationAction.ROTATE_ADAPTER,
+)
+
+
+# ---------------------------------------------------------------------------
+# Escalation policy
+# ---------------------------------------------------------------------------
+
+
+class EscalationPolicy:
+    """Track consecutive failures per adapter and decide escalation level.
+
+    The policy respects the caller's :class:`EscalationConfig` — it will
+    never suggest an action the caller has disabled.
+
+    Example::
+
+        config = EscalationConfig(reset_adapter=False)  # sensor service
+        policy = EscalationPolicy(["hci0", "hci1"], config=config)
+
+        action = policy.on_failure("hci0")
+        # action will never be RESET_ADAPTER because config disabled it
+
+        policy.on_success("hci0")  # resets failure counter
+    """
+
+    def __init__(
+        self,
+        adapters: list[str],
+        config: EscalationConfig | None = None,
+    ) -> None:
+        self._config = config or EscalationConfig()
+        self._adapters = adapters
+        self._max_level_idx = _LEVELS.index(self._config.max_escalation)
+        self._failures: dict[str, int] = {a: 0 for a in adapters}
+        self._last_reset: dict[str, float] = {a: 0.0 for a in adapters}
+
+    @property
+    def config(self) -> EscalationConfig:
+        """Return the current escalation configuration."""
+        return self._config
+
+    def on_failure(self, adapter: str) -> EscalationAction:
+        """Record a failure and return the next escalation action.
+
+        The returned action will never exceed *max_escalation* or
+        suggest a disabled level.
+        """
+        self._failures[adapter] = self._failures.get(adapter, 0) + 1
+        count = self._failures[adapter]
+
+        if (
+            count >= self._config.reset_after
+            and self._is_level_enabled(EscalationAction.RESET_ADAPTER)
+            and self._can_reset(adapter)
+        ):
+            return EscalationAction.RESET_ADAPTER
+
+        if count >= self._config.clear_after and self._is_level_enabled(
+            EscalationAction.CLEAR_BLUEZ
+        ):
+            return EscalationAction.CLEAR_BLUEZ
+
+        if count >= self._config.rotate_after and self._is_level_enabled(
+            EscalationAction.ROTATE_ADAPTER
+        ):
+            return EscalationAction.ROTATE_ADAPTER
+
+        if count >= 1 and self._is_level_enabled(EscalationAction.DIAGNOSE):
+            return EscalationAction.DIAGNOSE
+
+        return EscalationAction.RETRY
+
+    def on_success(self, adapter: str) -> None:
+        """Record a success — resets the failure counter for *adapter*."""
+        self._failures[adapter] = 0
+
+    def record_reset(self, adapter: str) -> None:
+        """Record that an adapter reset was performed."""
+        self._last_reset[adapter] = time.monotonic()
+        self._failures[adapter] = 0
+
+    def _is_level_enabled(self, level: EscalationAction) -> bool:
+        """Check if a given escalation level is enabled in config."""
+        if _LEVELS.index(level) > self._max_level_idx:
+            return False
+        level_config_map = {
+            EscalationAction.DIAGNOSE: self._config.diagnose_and_fix,
+            EscalationAction.CLEAR_BLUEZ: (
+                self._config.clear_bluez_on_inprogress_dominance
+            ),
+            EscalationAction.ROTATE_ADAPTER: self._config.rotate_adapter,
+            EscalationAction.RESET_ADAPTER: self._config.reset_adapter,
+        }
+        return level_config_map.get(level, True)
+
+    def _can_reset(self, adapter: str) -> bool:
+        """Check if enough time has passed since the last reset."""
+        last = self._last_reset.get(adapter, 0.0)
+        return (time.monotonic() - last) >= self._config.reset_cooldown
+
+
+# ---------------------------------------------------------------------------
+# Adapter reset utility
+# ---------------------------------------------------------------------------
+
+
+async def reset_adapter(
+    adapter: str,
+    restart_bluetoothd: bool = True,
+) -> bool:
+    """Reset a BLE adapter as a last resort.
+
+    This should only be called after all other recovery mechanisms have
+    failed.  It temporarily disrupts **ALL** BLE connections on the
+    adapter.
+
+    Sequence:
+
+    1. ``hciconfig <adapter> down``
+    2. sleep 1.0 s
+    3. ``hciconfig <adapter> up``
+    4. If *restart_bluetoothd* is ``True``, check whether ``bluetoothd``
+       survived the reset and restart it if not.
+
+    On Venus OS, ``bluetoothd`` can crash during adapter reset.  The
+    code checks ``pidof bluetoothd`` and restarts the daemon if it is
+    not running.
+
+    Returns ``True`` if the reset appeared successful (adapter is UP
+    and ``bluetoothd`` is running).
+    """
+    if not IS_LINUX:
+        return False
+    if not TOOLS.can_reset_adapter:
+        _LOGGER.warning(
+            "Cannot reset %s: hciconfig not found",
+            adapter,
+        )
+        return False
+
+    hciconfig = TOOLS.hciconfig
+    assert hciconfig is not None  # nosec — checked above
+
+    _LOGGER.warning("Resetting adapter %s (hciconfig down/up)", adapter)
+
+    try:
+        subprocess.run(  # nosec
+            [hciconfig, adapter, "down"],
+            capture_output=True,
+            timeout=5,
+        )
+    except Exception:
+        _LOGGER.exception("Failed to bring %s down", adapter)
+        return False
+
+    await asyncio.sleep(1.0)
+
+    try:
+        result = subprocess.run(  # nosec
+            [hciconfig, adapter, "up"],
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            _LOGGER.error(
+                "hciconfig %s up failed: %s",
+                adapter,
+                result.stderr.decode(errors="replace"),
+            )
+            return False
+    except Exception:
+        _LOGGER.exception("Failed to bring %s up", adapter)
+        return False
+
+    if restart_bluetoothd:
+        await asyncio.sleep(0.5)
+        try:
+            pidof = subprocess.run(  # nosec
+                ["pidof", "bluetoothd"],
+                capture_output=True,
+                timeout=3,
+            )
+            if pidof.returncode != 0:
+                _LOGGER.warning(
+                    "bluetoothd not running after %s reset, restarting",
+                    adapter,
+                )
+                subprocess.run(  # nosec
+                    ["/etc/init.d/bluetooth", "start"],
+                    capture_output=True,
+                    timeout=10,
+                )
+                await asyncio.sleep(3.0)
+        except Exception:
+            _LOGGER.debug(
+                "Failed to check/restart bluetoothd",
+                exc_info=True,
+            )
+
+    _LOGGER.info("Adapter %s reset complete", adapter)
+    return True

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,441 @@
+"""Tests for the recovery / escalation chain module."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bleak_retry_connector.recovery import (
+    PROFILE_BATTERY,
+    PROFILE_ON_DEMAND,
+    PROFILE_SENSOR,
+    TOOLS,
+    EscalationAction,
+    EscalationConfig,
+    EscalationPolicy,
+    ToolCapabilities,
+    reset_adapter,
+)
+
+# ---------------------------------------------------------------------------
+# ToolCapabilities tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolCapabilities:
+    """Tests for ToolCapabilities detection and properties."""
+
+    def test_detect_returns_instance(self):
+        """detect() should return a ToolCapabilities instance."""
+        caps = ToolCapabilities.detect()
+        assert isinstance(caps, ToolCapabilities)
+
+    def test_has_shell_tools_requires_both(self):
+        """has_shell_tools needs both bluetoothctl and hcitool."""
+        caps = ToolCapabilities(bluetoothctl="/usr/bin/bluetoothctl", hcitool=None)
+        assert caps.has_shell_tools is False
+
+        caps = ToolCapabilities(
+            bluetoothctl="/usr/bin/bluetoothctl", hcitool="/usr/bin/hcitool"
+        )
+        assert caps.has_shell_tools is True
+
+    def test_can_reset_adapter(self):
+        """can_reset_adapter needs hciconfig."""
+        caps = ToolCapabilities(hciconfig=None)
+        assert caps.can_reset_adapter is False
+
+        caps = ToolCapabilities(hciconfig="/usr/bin/hciconfig")
+        assert caps.can_reset_adapter is True
+
+    def test_can_diagnose(self):
+        """can_diagnose is the same as has_shell_tools."""
+        caps = ToolCapabilities(
+            bluetoothctl="/usr/bin/bluetoothctl", hcitool="/usr/bin/hcitool"
+        )
+        assert caps.can_diagnose is True
+
+    def test_frozen_dataclass(self):
+        """ToolCapabilities should be immutable."""
+        caps = ToolCapabilities(bluetoothctl="/usr/bin/bluetoothctl")
+        with pytest.raises(AttributeError):
+            caps.bluetoothctl = "/other/path"  # type: ignore[misc]
+
+    def test_module_level_tools_singleton(self):
+        """TOOLS module-level singleton should be a ToolCapabilities instance."""
+        assert isinstance(TOOLS, ToolCapabilities)
+
+
+# ---------------------------------------------------------------------------
+# EscalationConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationConfig:
+    """Tests for EscalationConfig defaults and profiles."""
+
+    def test_defaults(self):
+        """Default config has safe defaults."""
+        cfg = EscalationConfig()
+        assert cfg.diagnose_and_fix is True
+        assert cfg.clear_bluez_on_inprogress_dominance is True
+        assert cfg.rotate_adapter is True
+        assert cfg.reset_adapter is False
+        assert cfg.rotate_after == 2
+        assert cfg.clear_after == 4
+        assert cfg.reset_after == 6
+        assert cfg.reset_cooldown == 300.0
+        assert cfg.max_escalation == EscalationAction.RESET_ADAPTER
+
+    def test_profile_battery(self):
+        """Battery profile enables reset."""
+        assert PROFILE_BATTERY.reset_adapter is True
+        assert PROFILE_BATTERY.reset_after == 6
+        assert PROFILE_BATTERY.reset_cooldown == 300.0
+
+    def test_profile_sensor(self):
+        """Sensor profile caps at rotation, no reset."""
+        assert PROFILE_SENSOR.reset_adapter is False
+        assert PROFILE_SENSOR.max_escalation == EscalationAction.ROTATE_ADAPTER
+
+    def test_profile_on_demand(self):
+        """On-demand profile rotates fast, skips InProgress dominance."""
+        assert PROFILE_ON_DEMAND.clear_bluez_on_inprogress_dominance is False
+        assert PROFILE_ON_DEMAND.reset_adapter is False
+        assert PROFILE_ON_DEMAND.rotate_after == 1
+        assert PROFILE_ON_DEMAND.max_escalation == EscalationAction.ROTATE_ADAPTER
+
+
+# ---------------------------------------------------------------------------
+# EscalationAction tests
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationAction:
+    """Tests for the EscalationAction enum."""
+
+    def test_values(self):
+        vals = {
+            EscalationAction.RETRY: "retry",
+            EscalationAction.DIAGNOSE: "diagnose",
+            EscalationAction.CLEAR_BLUEZ: "clear_bluez",
+            EscalationAction.ROTATE_ADAPTER: "rotate",
+            EscalationAction.RESET_ADAPTER: "reset",
+        }
+        for action, expected in vals.items():
+            assert action.value == expected
+
+    def test_is_str_subclass(self):
+        """EscalationAction should be usable as a string."""
+        assert isinstance(EscalationAction.RETRY, str)
+
+
+# ---------------------------------------------------------------------------
+# EscalationPolicy tests
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationPolicy:
+    """Tests for the EscalationPolicy decision-making logic."""
+
+    def test_first_failure_returns_diagnose(self):
+        """First failure with default config should suggest DIAGNOSE."""
+        policy = EscalationPolicy(["hci0"])
+        action = policy.on_failure("hci0")
+        assert action == EscalationAction.DIAGNOSE
+
+    def test_rotate_after_threshold(self):
+        """After rotate_after failures, should suggest ROTATE_ADAPTER."""
+        policy = EscalationPolicy(["hci0", "hci1"])
+        policy.on_failure("hci0")  # 1 → DIAGNOSE
+        action = policy.on_failure("hci0")  # 2 → ROTATE
+        assert action == EscalationAction.ROTATE_ADAPTER
+
+    def test_clear_after_threshold(self):
+        """After clear_after failures, should suggest CLEAR_BLUEZ."""
+        policy = EscalationPolicy(["hci0"])
+        for _ in range(3):
+            policy.on_failure("hci0")
+        action = policy.on_failure("hci0")  # 4 → CLEAR
+        assert action == EscalationAction.CLEAR_BLUEZ
+
+    def test_reset_after_threshold(self):
+        """After reset_after failures, should suggest RESET_ADAPTER if enabled."""
+        config = EscalationConfig(reset_adapter=True)
+        policy = EscalationPolicy(["hci0"], config=config)
+        for _ in range(5):
+            policy.on_failure("hci0")
+        action = policy.on_failure("hci0")  # 6 → RESET
+        assert action == EscalationAction.RESET_ADAPTER
+
+    def test_reset_disabled_by_default(self):
+        """Default config does not enable reset — should fall back to CLEAR_BLUEZ."""
+        policy = EscalationPolicy(["hci0"])
+        for _ in range(10):
+            action = policy.on_failure("hci0")
+        # Even after many failures, should not suggest RESET
+        assert action != EscalationAction.RESET_ADAPTER
+
+    def test_on_success_resets_counter(self):
+        """on_success should reset the failure counter."""
+        policy = EscalationPolicy(["hci0"])
+        policy.on_failure("hci0")
+        policy.on_failure("hci0")
+        policy.on_success("hci0")
+        action = policy.on_failure("hci0")  # back to 1 → DIAGNOSE
+        assert action == EscalationAction.DIAGNOSE
+
+    def test_max_escalation_caps_actions(self):
+        """max_escalation should cap the returned action."""
+        config = EscalationConfig(
+            reset_adapter=True,
+            max_escalation=EscalationAction.ROTATE_ADAPTER,
+        )
+        policy = EscalationPolicy(["hci0"], config=config)
+        for _ in range(20):
+            action = policy.on_failure("hci0")
+        # Even after many failures, should not exceed ROTATE
+        assert action in (
+            EscalationAction.ROTATE_ADAPTER,
+            EscalationAction.CLEAR_BLUEZ,
+        )
+        assert action != EscalationAction.RESET_ADAPTER
+
+    def test_diagnose_disabled(self):
+        """If diagnose_and_fix is disabled, skip to next enabled level."""
+        config = EscalationConfig(diagnose_and_fix=False)
+        policy = EscalationPolicy(["hci0"], config=config)
+        action = policy.on_failure("hci0")
+        # diagnose disabled, failure count=1 (< rotate_after=2), so RETRY
+        assert action == EscalationAction.RETRY
+
+    def test_per_adapter_tracking(self):
+        """Failures are tracked per adapter."""
+        policy = EscalationPolicy(["hci0", "hci1"])
+        policy.on_failure("hci0")
+        policy.on_failure("hci0")  # hci0 at 2
+        action_hci1 = policy.on_failure("hci1")  # hci1 at 1
+        assert action_hci1 == EscalationAction.DIAGNOSE
+
+    def test_record_reset_clears_counter(self):
+        """record_reset should clear the failure counter and record time."""
+        config = EscalationConfig(reset_adapter=True)
+        policy = EscalationPolicy(["hci0"], config=config)
+        for _ in range(6):
+            policy.on_failure("hci0")
+        policy.record_reset("hci0")
+        action = policy.on_failure("hci0")  # back to 1
+        assert action == EscalationAction.DIAGNOSE
+
+    def test_reset_cooldown(self):
+        """Reset should be blocked during cooldown period."""
+        config = EscalationConfig(reset_adapter=True, reset_cooldown=300.0)
+        policy = EscalationPolicy(["hci0"], config=config)
+
+        # Simulate a recent reset
+        policy._last_reset["hci0"] = time.monotonic()
+
+        for _ in range(10):
+            action = policy.on_failure("hci0")
+        # Should not suggest RESET because cooldown hasn't elapsed
+        assert action != EscalationAction.RESET_ADAPTER
+
+    def test_reset_cooldown_expired(self):
+        """Reset should be allowed after cooldown expires."""
+        config = EscalationConfig(reset_adapter=True, reset_cooldown=0.0)
+        policy = EscalationPolicy(["hci0"], config=config)
+        for _ in range(5):
+            policy.on_failure("hci0")
+        action = policy.on_failure("hci0")  # 6 → RESET (cooldown=0)
+        assert action == EscalationAction.RESET_ADAPTER
+
+    def test_config_property(self):
+        """config property should return the current config."""
+        config = EscalationConfig(reset_adapter=True)
+        policy = EscalationPolicy(["hci0"], config=config)
+        assert policy.config is config
+
+    def test_default_config_if_none(self):
+        """If no config provided, should use default EscalationConfig."""
+        policy = EscalationPolicy(["hci0"])
+        assert isinstance(policy.config, EscalationConfig)
+        assert policy.config.reset_adapter is False
+
+    def test_unknown_adapter_on_failure(self):
+        """on_failure with an unknown adapter should still work."""
+        policy = EscalationPolicy(["hci0"])
+        # hci1 not in initial list but should be handled gracefully
+        action = policy.on_failure("hci1")
+        assert action == EscalationAction.DIAGNOSE
+
+    def test_sensor_profile_never_resets(self):
+        """Sensor profile should never suggest RESET_ADAPTER."""
+        policy = EscalationPolicy(["hci0", "hci1"], config=PROFILE_SENSOR)
+        for _ in range(20):
+            action = policy.on_failure("hci0")
+        assert action != EscalationAction.RESET_ADAPTER
+
+    def test_on_demand_profile_rotates_fast(self):
+        """On-demand profile should rotate after 1 failure."""
+        policy = EscalationPolicy(["hci0", "hci1"], config=PROFILE_ON_DEMAND)
+        action = policy.on_failure("hci0")  # 1 → ROTATE (rotate_after=1)
+        assert action == EscalationAction.ROTATE_ADAPTER
+
+
+# ---------------------------------------------------------------------------
+# reset_adapter tests
+# ---------------------------------------------------------------------------
+
+
+class TestResetAdapter:
+    """Tests for the reset_adapter utility function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_linux(self):
+        """reset_adapter should return False on non-Linux."""
+        with patch("bleak_retry_connector.recovery.IS_LINUX", False):
+            result = await reset_adapter("hci0")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_hciconfig(self):
+        """reset_adapter should return False when hciconfig is not found."""
+        tools_no_hciconfig = ToolCapabilities(hciconfig=None)
+        with (
+            patch("bleak_retry_connector.recovery.IS_LINUX", True),
+            patch("bleak_retry_connector.recovery.TOOLS", tools_no_hciconfig),
+        ):
+            result = await reset_adapter("hci0")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_calls_hciconfig_down_up(self):
+        """reset_adapter should call hciconfig down then up."""
+        mock_tools = ToolCapabilities(
+            hciconfig="/usr/bin/hciconfig",
+            bluetoothctl="/usr/bin/bluetoothctl",
+        )
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+
+        async def fast_sleep(_):
+            pass
+
+        with (
+            patch("bleak_retry_connector.recovery.IS_LINUX", True),
+            patch("bleak_retry_connector.recovery.TOOLS", mock_tools),
+            patch("bleak_retry_connector.recovery.subprocess.run", mock_run),
+            patch("bleak_retry_connector.recovery.asyncio.sleep", fast_sleep),
+        ):
+            result = await reset_adapter("hci0", restart_bluetoothd=False)
+
+        assert result is True
+        calls = mock_run.call_args_list
+        assert len(calls) == 2
+        assert calls[0][0][0] == ["/usr/bin/hciconfig", "hci0", "down"]
+        assert calls[1][0][0] == ["/usr/bin/hciconfig", "hci0", "up"]
+
+    @pytest.mark.asyncio
+    async def test_restarts_bluetoothd_if_dead(self):
+        """reset_adapter should restart bluetoothd if it died."""
+        mock_tools = ToolCapabilities(
+            hciconfig="/usr/bin/hciconfig",
+            bluetoothctl="/usr/bin/bluetoothctl",
+        )
+
+        call_log: list[list[str]] = []
+
+        def mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            result = MagicMock()
+            if cmd[0] == "pidof":
+                result.returncode = 1  # bluetoothd not running
+            else:
+                result.returncode = 0
+            return result
+
+        async def fast_sleep(_):
+            pass
+
+        with (
+            patch("bleak_retry_connector.recovery.IS_LINUX", True),
+            patch("bleak_retry_connector.recovery.TOOLS", mock_tools),
+            patch("bleak_retry_connector.recovery.subprocess.run", mock_run),
+            patch("bleak_retry_connector.recovery.asyncio.sleep", fast_sleep),
+        ):
+            result = await reset_adapter("hci0", restart_bluetoothd=True)
+
+        assert result is True
+        pidof_calls = [c for c in call_log if c[0] == "pidof"]
+        assert len(pidof_calls) == 1
+        bluetooth_calls = [c for c in call_log if "/etc/init.d/bluetooth" in str(c)]
+        assert len(bluetooth_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_down_failure(self):
+        """reset_adapter should return False if hciconfig down raises."""
+        mock_tools = ToolCapabilities(hciconfig="/usr/bin/hciconfig")
+
+        with (
+            patch("bleak_retry_connector.recovery.IS_LINUX", True),
+            patch("bleak_retry_connector.recovery.TOOLS", mock_tools),
+            patch(
+                "bleak_retry_connector.recovery.subprocess.run",
+                side_effect=OSError("command failed"),
+            ),
+        ):
+            result = await reset_adapter("hci0")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_up_nonzero(self):
+        """reset_adapter should return False if hciconfig up returns non-zero."""
+        mock_tools = ToolCapabilities(hciconfig="/usr/bin/hciconfig")
+
+        call_count = 0
+
+        def mock_run(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.returncode = 0  # down succeeds
+            else:
+                result.returncode = 1  # up fails
+                result.stderr = b"some error"
+            return result
+
+        async def fast_sleep(_):
+            pass
+
+        with (
+            patch("bleak_retry_connector.recovery.IS_LINUX", True),
+            patch("bleak_retry_connector.recovery.TOOLS", mock_tools),
+            patch("bleak_retry_connector.recovery.subprocess.run", mock_run),
+            patch("bleak_retry_connector.recovery.asyncio.sleep", fast_sleep),
+        ):
+            result = await reset_adapter("hci0", restart_bluetoothd=False)
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: importability from top-level
+# ---------------------------------------------------------------------------
+
+
+def test_importable_from_top_level():
+    """All recovery symbols should be importable from bleak_retry_connector."""
+    from bleak_retry_connector import (  # noqa: F401
+        PROFILE_BATTERY,
+        PROFILE_ON_DEMAND,
+        PROFILE_SENSOR,
+        TOOLS,
+        EscalationAction,
+        EscalationConfig,
+        EscalationPolicy,
+        ToolCapabilities,
+        reset_adapter,
+    )


### PR DESCRIPTION
## Summary

Add a recovery module with a configurable escalation policy for BLE adapter failures. This provides the decision-making framework for escalating from simple retries through diagnostic fixes, BlueZ state cleanup, adapter rotation, and adapter reset.

**Components:**

- **`ToolCapabilities`** — auto-detect available system tools (`bluetoothctl`, `hcitool`, `hciconfig`, `rfkill`) once at import time via `shutil.which()`. Provides `has_shell_tools`, `can_reset_adapter`, and `can_diagnose` properties. Replaces scattered ad-hoc `shutil.which()` calls with a single source of truth.

- **`EscalationConfig`** — dataclass for configuring the escalation chain. Each level can be individually enabled/disabled with configurable thresholds:
  - `diagnose_and_fix` — stuck-state diagnosis + targeted fix
  - `clear_bluez_on_inprogress_dominance` — BlueZ cleanup when InProgress errors dominate all adapters
  - `rotate_adapter` — adapter rotation on failure
  - `reset_adapter` — adapter reset as last resort (**default OFF**)
  - `max_escalation` — hard ceiling on escalation level

- **`EscalationPolicy`** — state machine that tracks consecutive failures per adapter and returns the appropriate `EscalationAction`. Respects caller configuration — never suggests a disabled action. Supports:
  - Per-adapter failure tracking
  - Reset cooldown period
  - `on_success()` to reset counters
  - `record_reset()` to track cooldown

- **`reset_adapter()`** — standalone last-resort utility: `hciconfig down/up` with optional `bluetoothd` restart detection (critical for Venus OS where bluetoothd can crash during adapter reset)

- **Pre-built profiles** for common service types:
  - `PROFILE_BATTERY` — full escalation, owns the adapter
  - `PROFILE_SENSOR` — never reset, caps at rotation
  - `PROFILE_ON_DEMAND` — fast rotation, skips InProgress dominance cleanup

**Escalation levels (least to most disruptive):**

```
1. RETRY           — simple backoff retry
2. DIAGNOSE        — diagnose stuck state + targeted fix
3. CLEAR_BLUEZ     — clear InProgress-dominant stale BlueZ state
4. ROTATE_ADAPTER  — switch to a different adapter
5. RESET_ADAPTER   — hciconfig down/up (disrupts ALL connections)
```

## Stuck States Addressed

Based on production incidents documented in our [field guide](https://github.com/TechBlueprints/bleak-retry-improvements/blob/main/12-observed-stuck-states.md):

| Stuck State | How This PR Helps |
|---|---|
| **State 10: InProgress Dominance** (all adapters stuck) | `EscalationPolicy` detects when failures reach the `clear_after` threshold and recommends `CLEAR_BLUEZ` — the caller can then clear stale BlueZ state on all adapters |
| **State 11: bluetoothd Crash** after adapter reset | `reset_adapter()` checks `pidof bluetoothd` after reset and restarts the daemon if it died |
| **State 12: Deep Corruption** (multiple phantoms, stuck HCI) | `EscalationPolicy` recommends `RESET_ADAPTER` after `reset_after` consecutive failures, providing the final escalation step when all targeted fixes fail |
| **State 22: USB Adapter DOWN** | `reset_adapter()` can bring a down adapter back up via `hciconfig up` |

**Design notes:**
- `reset_adapter()` is never called automatically — callers opt in via `EscalationConfig(reset_adapter=True)`.
- The diagnostic framework (`diagnose_stuck_state`, `StuckState`) is designed to plug into the `DIAGNOSE` level in a future PR.
- `ToolCapabilities.detect()` runs once at import; results are cached as the `TOOLS` module singleton.

## Test Plan

- [x] 36 new unit tests covering all components:
  - `ToolCapabilities`: detection, properties, immutability, module singleton
  - `EscalationConfig`: defaults, all three pre-built profiles
  - `EscalationAction`: enum values, str subclass
  - `EscalationPolicy`: thresholds, per-adapter tracking, success reset, cooldown, max_escalation cap, disabled levels, unknown adapters
  - `reset_adapter()`: non-Linux guard, missing hciconfig, down/up sequence, bluetoothd restart, error handling
  - Import verification from top-level package
- [x] All 90 existing tests still pass
- [x] All pre-commit hooks pass (isort, black, flake8, mypy, bandit)


Made with [Cursor](https://cursor.com)