### PR TITLE
feat: add optional validate_connection callback to establish_connection

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -405,9 +405,18 @@ async def establish_connection(
     ble_device_callback: Callable[[], BLEDevice] | None = None,
     use_services_cache: bool = True,
     pair: bool = False,
+    validate_connection: Callable[[AnyBleakClient], Awaitable[bool]] | None = None,
     **kwargs: Any,
 ) -> AnyBleakClient:
-    """Establish a connection to the device."""
+    """Establish a connection to the device.
+
+    If ``validate_connection`` is provided it is called after every
+    successful ``connect()`` with the connected client.  The callback
+    should return ``True`` when the connection is usable.  Returning
+    ``False`` or raising any exception is treated as a validation
+    failure — the client is disconnected and the attempt is retried
+    until ``max_attempts`` is exhausted.
+    """
     timeouts = 0
     connect_errors = 0
     transient_errors = 0
@@ -583,7 +592,40 @@ async def establish_connection(
             await wait_for_disconnect(device, backoff_time)
             _raise_if_needed(name, device.address, exc)
         else:
-            return client
+            if validate_connection is not None:
+                try:
+                    valid = await validate_connection(client)
+                except Exception:
+                    _LOGGER.debug(
+                        "%s - %s: Connection validation raised an "
+                        "exception, treating as failure (attempt: %s)",
+                        name,
+                        device.address,
+                        attempt,
+                    )
+                    valid = False
+                if not valid:
+                    connect_errors += 1
+                    _LOGGER.debug(
+                        "%s - %s: Connection validation failed " "(attempt: %s)",
+                        name,
+                        device.address,
+                        attempt,
+                    )
+                    await client.disconnect()
+                    await wait_for_disconnect(device, BLEAK_BACKOFF_TIME)
+                    _raise_if_needed(
+                        name,
+                        device.address,
+                        BleakError(
+                            f"{name} - {device.address}: "
+                            "Connection validation failed"
+                        ),
+                    )
+                else:
+                    return client
+            else:
+                return client
         # Ensure the disconnect callback
         # has a chance to run before we try to reconnect
         await asyncio.sleep(0)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2346,3 +2346,136 @@ async def test_has_valid_services_in_cache_esphome_proxy(mock_linux):
     # Should return True for non-BlueZ devices (ESPHome proxy)
     result = await bleak_retry_connector._has_valid_services_in_cache(device)
     assert result is True
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_validate_connection_passes():
+    """Connection returned when validate_connection returns True."""
+
+    class FakeBleakClient(BleakClient):
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    async def _validator(client):
+        return True
+
+    client = await establish_connection(
+        FakeBleakClient,
+        MagicMock(),
+        "test",
+        disconnected_callback=MagicMock(),
+        validate_connection=_validator,
+    )
+    assert isinstance(client, FakeBleakClient)
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_validate_connection_fails_then_passes():
+    """Validation failure triggers disconnect and retry, then succeeds."""
+    call_count = 0
+    disconnect_count = 0
+
+    class FakeBleakClient(BleakClient):
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            nonlocal disconnect_count
+            disconnect_count += 1
+
+    async def _validator(client):
+        nonlocal call_count
+        call_count += 1
+        return call_count > 1
+
+    client = await establish_connection(
+        FakeBleakClient,
+        MagicMock(),
+        "test",
+        disconnected_callback=MagicMock(),
+        validate_connection=_validator,
+    )
+    assert isinstance(client, FakeBleakClient)
+    assert call_count == 2
+    assert disconnect_count == 1
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_validate_connection_exception_treated_as_false():
+    """Exception from validate_connection is treated as failure."""
+    call_count = 0
+    disconnect_count = 0
+
+    class FakeBleakClient(BleakClient):
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            nonlocal disconnect_count
+            disconnect_count += 1
+
+    async def _validator(client):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("GATT read failed")
+        return True
+
+    client = await establish_connection(
+        FakeBleakClient,
+        MagicMock(),
+        "test",
+        disconnected_callback=MagicMock(),
+        validate_connection=_validator,
+    )
+    assert isinstance(client, FakeBleakClient)
+    assert call_count == 2
+    assert disconnect_count == 1
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_validate_connection_exhausts_retries():
+    """Validation always failing exhausts max_attempts and raises."""
+
+    class FakeBleakClient(BleakClient):
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    async def _validator(client):
+        return False
+
+    with pytest.raises(BleakConnectionError, match="validation failed"):
+        await establish_connection(
+            FakeBleakClient,
+            MagicMock(),
+            "test",
+            disconnected_callback=MagicMock(),
+            max_attempts=3,
+            validate_connection=_validator,
+        )
+
+
+@pytest.mark.asyncio
+async def test_establish_connection_no_validate_connection():
+    """Without validate_connection, behaviour is unchanged."""
+
+    class FakeBleakClient(BleakClient):
+        async def connect(self, *args, **kwargs):
+            pass
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    client = await establish_connection(
+        FakeBleakClient,
+        MagicMock(),
+        "test",
+        disconnected_callback=MagicMock(),
+    )
+    assert isinstance(client, FakeBleakClient)


### PR DESCRIPTION
## Summary

- Adds an optional `validate_connection` parameter to `establish_connection()` — an async callback `Callable[[BleakClient], Awaitable[bool]]` that is invoked after every successful `connect()`.
- If the callback returns `False` or raises **any** exception, the client is disconnected and the attempt is retried until `max_attempts` is exhausted.
- Defaults to `None` so existing callers are completely unaffected — no API contract change.

### Motivation

A successful BLE `connect()` does not guarantee the connection is actually usable.  The device may accept the connection but fail to respond to GATT reads/writes.  This callback lets the calling application verify the connection is live (e.g. read a characteristic, send a command and check the response) before `establish_connection` returns.

### Example usage

```python
async def validate(client: BleakClient) -> bool:
    """Read the device info characteristic to prove the link is alive."""
    value = await client.read_gatt_char("00002a29-0000-1000-8000-00805f9b34fb")
    return len(value) > 0

client = await establish_connection(
    BleakClient,
    device,
    "my-sensor",
    validate_connection=validate,
)
```

## Test plan

- [x] `test_establish_connection_validate_connection_passes` — callback returns True, client returned
- [x] `test_establish_connection_validate_connection_fails_then_passes` — first call returns False (disconnect + retry), second call returns True
- [x] `test_establish_connection_validate_connection_exception_treated_as_false` — callback raises RuntimeError, treated as failure, retry succeeds
- [x] `test_establish_connection_validate_connection_exhausts_retries` — callback always returns False, raises BleakConnectionError after max_attempts
- [x] `test_establish_connection_no_validate_connection` — no callback provided, behaviour unchanged
- [x] All existing tests pass (50 passed, 1 skipped)
- [x] All pre-commit hooks pass (black, flake8, mypy, bandit, isort, etc.)

Made with [Cursor](https://cursor.com)