### PR TITLE
chore: replace isort and black with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,14 +40,12 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
-  - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: isort
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
-    hooks:
-      - id: black
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,15 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 
-[tool.isort]
-profile = "black"
-known_first_party = ["bleak_retry_connector", "tests"]
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["bleak_retry_connector", "tests"]
 
 [tool.mypy]
 check_untyped_defs = true

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -157,7 +157,7 @@ ABORT_ADVICE = (
 )
 
 DEVICE_MISSING_ADVICE = (
-    "The device disappeared; " "Try restarting the scanner or moving the device closer"
+    "The device disappeared; Try restarting the scanner or moving the device closer"
 )
 
 OUT_OF_SLOTS_ADVICE = (

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -48,7 +48,6 @@ class AllocationChange(Enum):
 
 @dataclass(slots=True)
 class AllocationChangeEvent:
-
     change: AllocationChange
     path: str | None  # D-Bus object path of the device
     adapter: str  # Adapter/Controller (hciX)
@@ -57,7 +56,6 @@ class AllocationChangeEvent:
 
 @dataclass(slots=True)
 class Allocations:
-
     adapter: str  # Adapter/Controller (hciX)
     slots: int  # Number of slots
     free: int  # Number of free slots


### PR DESCRIPTION
## Summary

- Replace the `isort` and `black-pre-commit-mirror` hooks with `ruff-check` (with `--fix` for import sorting via the `I` rule) and `ruff-format`.
- Drop `[tool.isort]` from `pyproject.toml`; add equivalent `[tool.ruff]` config (line-length 88, target-version py310) and `[tool.ruff.lint.isort]` with `known-first-party = ["bleak_retry_connector", "tests"]`.
- Reformat the codebase with ruff — two small cosmetic changes:
  - `__init__.py`: collapse adjacent implicit-concat string literals.
  - `bluez.py`: remove blank lines immediately after `@dataclass` class declarations.

## Motivation

Avoids recurring pre-commit.ci churn (most recently isort `9.0.0a3` collapsing imports in a way black then re-wraps, looping the lint job — see #244). Consolidates formatting + import sorting into a single fast tool.

## Test plan

- [x] `pre-commit run --all-files` passes locally
- [x] `pytest` passes locally (56 passed, 1 skipped)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)