### PR TITLE
fix: report rssi and attempt breakdown in connect errors

### DIFF
--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -437,7 +437,9 @@ async def establish_connection(
             return
         msg = (
             f"{name} - {description}: Failed to connect after "
-            f"{attempt} attempt(s): {str(exc) or type(exc).__name__}"
+            f"{attempt} attempt(s) (timeouts={timeouts}, "
+            f"connect_errors={connect_errors}, transient_errors={transient_errors}): "
+            f"{str(exc) or type(exc).__name__}"
         )
         # Sure would be nice if bleak gave us typed exceptions
         if isinstance(exc, asyncio.TimeoutError):
@@ -456,12 +458,20 @@ async def establish_connection(
         raise BleakConnectionError(msg) from exc
 
     debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
-    rssi: int | None = None
     if IS_LINUX and (devices := await get_connected_devices(device)):
         # Bleak 0.17 will handle already connected devices for us so
         # if we are already connected we swap the device to the connected
         # device.
         device = devices[0]
+
+    # Best-effort last known RSSI for the connect logs. BlueZ stores it on the
+    # device details; other backends (e.g. ESPHome proxies) do not, so leave it
+    # as None when unavailable.
+    rssi: int | None = None
+    if isinstance(details := device.details, dict) and isinstance(
+        props := details.get("props"), dict
+    ):
+        rssi = props.get("RSSI")
 
     client = client_class(
         device,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -574,7 +574,8 @@ async def test_establish_connection_has_transient_error_had_advice():
     assert isinstance(exc, BleakAbortedError)
     assert str(exc) == (
         "test - aa:bb:cc:dd:ee:ff: "
-        "Failed to connect after 9 attempt(s): "
+        "Failed to connect after 9 attempt(s) "
+        "(timeouts=0, connect_errors=0, transient_errors=9): "
         "le-connection-abort-by-local: "
         "Interference/range; "
         "External Bluetooth adapter w/extension may help; "
@@ -606,7 +607,8 @@ async def test_establish_connection_out_of_slots_advice():
 
     assert isinstance(exc, BleakOutOfConnectionSlotsError)
     assert str(exc) == (
-        "test - aa:bb:cc:dd:ee:ff: Failed to connect after 9 attempt(s): "
+        "test - aa:bb:cc:dd:ee:ff: Failed to connect after 9 attempt(s) "
+        "(timeouts=0, connect_errors=0, transient_errors=9): "
         "out of connection slots: The proxy/adapter is "
         "out of connection slots or the device is no "
         "longer reachable; Add additional proxies "
@@ -640,7 +642,8 @@ async def test_establish_connection_esp_gatt_conn_conn_cancel_out_of_slots():
 
     assert isinstance(exc, BleakOutOfConnectionSlotsError)
     assert str(exc) == (
-        "test - aa:bb:cc:dd:ee:ff: Failed to connect after 9 attempt(s): "
+        "test - aa:bb:cc:dd:ee:ff: Failed to connect after 9 attempt(s) "
+        "(timeouts=0, connect_errors=0, transient_errors=9): "
         "ESP_GATT_CONN_CONN_CANCEL: The proxy/adapter is "
         "out of connection slots or the device is no "
         "longer reachable; Add additional proxies "
@@ -682,12 +685,48 @@ async def test_device_disappeared_error():
     assert isinstance(exc, BleakNotFoundError)
     assert str(exc) == (
         "test - aa:bb:cc:dd:ee:ff: "
-        "Failed to connect after 4 attempt(s): "
+        "Failed to connect after 4 attempt(s) "
+        "(timeouts=0, connect_errors=4, transient_errors=0): "
         "[org.freedesktop.DBus.Error.UnknownObject] "
         'Method "Connect" with signature "" on interface "org.bluez.Device1" '
         "doesn't exist: The device disappeared; "
         "Try restarting the scanner or moving the device closer"
     )
+
+
+@pytest.mark.asyncio
+async def test_connect_log_includes_rssi_from_bluez_details(caplog):
+    """The connect debug logs report the device's last known BlueZ RSSI."""
+    import logging
+
+    class FakeBleakClient(BleakClient):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self, *args, **kwargs):
+            raise BleakError("le-connection-abort-by-local")
+
+        async def disconnect(self, *args, **kwargs):
+            pass
+
+    with (
+        patch("bleak_retry_connector.calculate_backoff_time", return_value=0),
+        caplog.at_level(logging.DEBUG),
+    ):
+        try:
+            await establish_connection(
+                FakeBleakClient,
+                BLEDevice(
+                    "aa:bb:cc:dd:ee:ff",
+                    "name",
+                    {"path": "/org/bluez/hci0/dev_AA", "props": {"RSSI": -65}},
+                ),
+                "test",
+            )
+        except BleakError:
+            pass
+
+    assert "last rssi: -65" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -785,7 +824,8 @@ async def test_device_disappeared_and_reappears():
     assert isinstance(exc, BleakNotFoundError)
     assert str(exc) == (
         "test - FA:23:9D:AA:45:46: "
-        "Failed to connect after 9 attempt(s): "
+        "Failed to connect after 9 attempt(s) "
+        "(timeouts=0, connect_errors=0, transient_errors=9): "
         "BleakDeviceNotFoundError: "
         "The device disappeared; "
         "Try restarting the scanner or moving the device closer"


### PR DESCRIPTION
Two small diagnostic improvements for connection failures.

The `rssi` used in the connect debug logs was declared but never assigned, so every "last rssi" line printed None; it now reads the last known RSSI from the BlueZ device details when available (other backends leave it None).

The raised connect error now includes the attempt breakdown (timeouts, connect_errors, transient_errors) so an intermittent failure shows whether it was timing out, hitting hard errors, or churning on transient ones.

Independent of the habluetooth and Home Assistant work for home-assistant/core#170232.