### PR TITLE
feat: add restore_discoveries_sync

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -562,6 +562,16 @@ async def restore_discoveries(scanner: BleakScanner, adapter: str) -> None
 
 No-op on non-Linux platforms.
 
+```python
+def restore_discoveries_sync(scanner: BleakScanner, adapter: str) -> None
+```
+
+Same seeding without awaiting, for callers that restart a scanner in place
+(bleak clears `seen_devices` on every `start()`). It reads the BlueZ manager
+bleak already built for the running event loop, so call it from the loop
+after the scanner has started; no-op when there is no such manager, off the
+loop, or on non-Linux platforms.
+
 ## get_device / get_device_by_adapter
 
 Look up a `BLEDevice` by MAC address against BlueZ's current view of the bus.

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -19,6 +19,7 @@ from .bluez import (  # noqa: F401
     Allocations,
     BleakSlotManager,
     _get_properties,
+    _get_properties_sync,
     _get_services_cache,
     clear_cache,
     device_source,
@@ -69,6 +70,7 @@ __all__ = [
     "get_device_by_adapter",
     "device_source",
     "restore_discoveries",
+    "restore_discoveries_sync",
     "retry_bluetooth_connection_error",
     "BleakClientWithServiceCache",
     "BleakAbortedError",
@@ -643,6 +645,28 @@ async def restore_discoveries(scanner: BleakScanner, adapter: str) -> None:
     if not (properties := await _get_properties()):
         _LOGGER.debug("Failed to restore discoveries for %s", adapter)
         return
+    _restore_discoveries(scanner, adapter, properties)
+
+
+def restore_discoveries_sync(scanner: BleakScanner, adapter: str) -> None:
+    """Restore discoveries from a BlueZ manager that is already running.
+
+    Same as restore_discoveries but never awaits: it reads the manager
+    bleak created for the running loop, so call it after the scanner
+    has started. A no-op when there is no such manager.
+    """
+    if not IS_LINUX:
+        return
+    if not (properties := _get_properties_sync()):
+        _LOGGER.debug("Failed to restore discoveries for %s", adapter)
+        return
+    _restore_discoveries(scanner, adapter, properties)
+
+
+def _restore_discoveries(
+    scanner: BleakScanner, adapter: str, properties: dict[str, Any]
+) -> None:
+    """Seed the scanner's seen devices from the managed objects."""
     backend = scanner._backend
     before = len(backend.seen_devices)
     details: dict[str, Any]

--- a/src/bleak_retry_connector/__init__.py
+++ b/src/bleak_retry_connector/__init__.py
@@ -652,19 +652,21 @@ def restore_discoveries_sync(scanner: BleakScanner, adapter: str) -> None:
     """Restore discoveries from a BlueZ manager that is already running.
 
     Same as restore_discoveries but never awaits: it reads the manager
-    bleak created for the running loop, so call it after the scanner
-    has started. A no-op when there is no such manager.
+    bleak created for the running loop, so call it from the loop after
+    the scanner has started. A no-op when there is no such manager.
     """
     if not IS_LINUX:
         return
     if not (properties := _get_properties_sync()):
-        _LOGGER.debug("Failed to restore discoveries for %s", adapter)
+        _LOGGER.debug("No running BlueZ manager to restore discoveries for %s", adapter)
         return
     _restore_discoveries(scanner, adapter, properties)
 
 
 def _restore_discoveries(
-    scanner: BleakScanner, adapter: str, properties: dict[str, Any]
+    scanner: BleakScanner,
+    adapter: str,
+    properties: dict[str, dict[str, dict[str, Any]]],
 ) -> None:
     """Seed the scanner's seen devices from the managed objects."""
     backend = scanner._backend

--- a/src/bleak_retry_connector/bleak_manager.py
+++ b/src/bleak_retry_connector/bleak_manager.py
@@ -23,13 +23,23 @@ if IS_LINUX:
         )
 
 
+def get_global_bluez_manager_sync() -> BlueZManager | None:
+    """Return the BlueZ manager bleak built for the running loop, if any."""
+    if not _global_instances:
+        return None
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+    return _global_instances.get(loop)
+
+
 async def get_global_bluez_manager_with_timeout() -> BlueZManager | None:
     """Get the properties."""
     if not IS_LINUX:
         return None
 
-    loop = asyncio.get_running_loop()
-    if _global_instances and (manager := _global_instances.get(loop)):
+    if manager := get_global_bluez_manager_sync():
         return manager
 
     if (

--- a/src/bleak_retry_connector/bleak_manager.py
+++ b/src/bleak_retry_connector/bleak_manager.py
@@ -30,6 +30,7 @@ def get_global_bluez_manager_sync() -> BlueZManager | None:
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
+        _LOGGER.debug("get_global_bluez_manager_sync called off the event loop")
         return None
     return _global_instances.get(loop)
 

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -14,8 +14,10 @@ from bleak import BleakGATTServiceCollection
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
-from . import bleak_manager
-from .bleak_manager import get_global_bluez_manager_with_timeout
+from .bleak_manager import (
+    get_global_bluez_manager_sync,
+    get_global_bluez_manager_with_timeout,
+)
 from .const import (
     DISCONNECT_TIMEOUT,
     IS_LINUX,
@@ -263,9 +265,7 @@ async def _get_properties() -> dict[str, dict[str, dict[str, Any]]] | None:
 
 def _get_properties_sync() -> dict[str, dict[str, dict[str, Any]]] | None:
     """Get the properties from an already running BlueZ manager, or None."""
-    if not (instances := bleak_manager._global_instances):
-        return None
-    if bluez_manager := instances.get(asyncio.get_running_loop()):
+    if bluez_manager := get_global_bluez_manager_sync():
         return bluez_manager._properties  # pylint: disable=protected-access
     return None
 

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -263,9 +263,9 @@ async def _get_properties() -> dict[str, dict[str, dict[str, Any]]] | None:
 
 def _get_properties_sync() -> dict[str, dict[str, dict[str, Any]]] | None:
     """Get the properties from an already running BlueZ manager, or None."""
-    if not IS_LINUX or not bleak_manager._global_instances:
+    if not (instances := bleak_manager._global_instances):
         return None
-    if bluez_manager := bleak_manager._global_instances.get(asyncio.get_running_loop()):
+    if bluez_manager := instances.get(asyncio.get_running_loop()):
         return bluez_manager._properties  # pylint: disable=protected-access
     return None
 

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -14,6 +14,7 @@ from bleak import BleakGATTServiceCollection
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
+from . import bleak_manager
 from .bleak_manager import get_global_bluez_manager_with_timeout
 from .const import (
     DISCONNECT_TIMEOUT,
@@ -256,6 +257,15 @@ class BleakSlotManager:
 async def _get_properties() -> dict[str, dict[str, dict[str, Any]]] | None:
     """Get the properties."""
     if bluez_manager := await get_global_bluez_manager_with_timeout():
+        return bluez_manager._properties  # pylint: disable=protected-access
+    return None
+
+
+def _get_properties_sync() -> dict[str, dict[str, dict[str, Any]]] | None:
+    """Get the properties from an already running BlueZ manager, or None."""
+    if not IS_LINUX or not bleak_manager._global_instances:
+        return None
+    if bluez_manager := bleak_manager._global_instances.get(asyncio.get_running_loop()):
         return bluez_manager._properties  # pylint: disable=protected-access
     return None
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2858,6 +2858,19 @@ async def test_restore_discoveries_sync_no_manager(mock_linux: None) -> None:
 
 
 @pytest.mark.asyncio
+async def test_restore_discoveries_sync_other_loop(mock_linux: None) -> None:
+    """A manager registered for another loop is not used."""
+    mock_backend = Mock(seen_devices={})
+    with patch.object(
+        bleak_retry_connector.bleak_manager,
+        "_global_instances",
+        {asyncio.new_event_loop(): Mock(_properties={"/x": {}})},
+    ):
+        restore_discoveries_sync(Mock(_backend=mock_backend), "hci0")
+    assert mock_backend.seen_devices == {}
+
+
+@pytest.mark.asyncio
 async def test_restore_discoveries_sync_non_linux(mock_macos: None) -> None:
     """restore_discoveries_sync is a no-op off Linux."""
     mock_backend = Mock(seen_devices={})

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2870,6 +2870,8 @@ async def test_restore_discoveries_sync_other_loop(mock_linux: None) -> None:
     assert mock_backend.seen_devices == {}
 
 
+# Intentionally sync: no running loop, so this is the only test of the
+# RuntimeError branch in get_global_bluez_manager_sync.
 def test_restore_discoveries_sync_no_running_loop(mock_linux: None) -> None:
     """Off the loop restore_discoveries_sync is a no-op, not an error."""
     mock_backend = Mock(seen_devices={})
@@ -2880,6 +2882,12 @@ def test_restore_discoveries_sync_no_running_loop(mock_linux: None) -> None:
     ):
         restore_discoveries_sync(Mock(_backend=mock_backend), "hci0")
     assert mock_backend.seen_devices == {}
+
+
+@pytest.mark.skipif("not bleak_retry_connector.const.IS_LINUX")
+def test_bleak_global_instances_imported() -> None:
+    """The bleak private the sync lookup relies on still imports."""
+    assert bleak_retry_connector.bleak_manager._global_instances is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2864,7 +2864,19 @@ async def test_restore_discoveries_sync_other_loop(mock_linux: None) -> None:
     with patch.object(
         bleak_retry_connector.bleak_manager,
         "_global_instances",
-        {asyncio.new_event_loop(): Mock(_properties={"/x": {}})},
+        {Mock(): Mock(_properties={"/x": {}})},
+    ):
+        restore_discoveries_sync(Mock(_backend=mock_backend), "hci0")
+    assert mock_backend.seen_devices == {}
+
+
+def test_restore_discoveries_sync_no_running_loop(mock_linux: None) -> None:
+    """Off the loop restore_discoveries_sync is a no-op, not an error."""
+    mock_backend = Mock(seen_devices={})
+    with patch.object(
+        bleak_retry_connector.bleak_manager,
+        "_global_instances",
+        {Mock(): Mock(_properties={"/x": {}})},
     ):
         restore_discoveries_sync(Mock(_backend=mock_backend), "hci0")
     assert mock_backend.seen_devices == {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -40,6 +40,7 @@ from bleak_retry_connector import (
     get_device,
     get_device_by_adapter,
     restore_discoveries,
+    restore_discoveries_sync,
     retry_bluetooth_connection_error,
 )
 from bleak_retry_connector.bleak_manager import _reset_dbus_socket_cache
@@ -2797,6 +2798,70 @@ async def test_restore_discoveries_non_linux(mock_macos: None) -> None:
         await restore_discoveries(mock_scanner, "hci0")
 
     get_props.assert_not_called()
+    assert mock_backend.seen_devices == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif("not bleak_retry_connector.const.IS_LINUX")
+async def test_restore_discoveries_sync(mock_linux: None) -> None:
+    """restore_discoveries_sync reads the manager of the running loop."""
+
+    class FakeBluezManager:
+        _properties = {
+            "/org/bluez/hci1/dev_BD_24_6F_85_AA_61": {
+                "org.bluez.Device1": {
+                    "Address": "BD:24:6F:85:AA:61",
+                    "AddressType": "public",
+                    "Name": "Dream~BD246F85AA61",
+                    "Alias": "Dream~BD246F85AA61",
+                    "Paired": False,
+                    "Trusted": False,
+                    "Blocked": False,
+                    "LegacyPairing": False,
+                    "Connected": False,
+                    "UUIDs": [],
+                    "Adapter": "/org/bluez/hci1",
+                    "ServicesResolved": False,
+                    "RSSI": -60,
+                },
+            },
+        }
+
+    from bluetooth_adapters.history import load_history_from_managed_objects
+
+    seen_devices: dict[str, tuple[BLEDevice, AdvertisementData]] = {}
+    mock_scanner = Mock(_backend=Mock(seen_devices=seen_devices))
+    with (
+        patch.object(
+            bleak_retry_connector.bleak_manager,
+            "_global_instances",
+            {asyncio.get_running_loop(): FakeBluezManager()},
+        ),
+        patch.object(
+            bleak_retry_connector,
+            "load_history_from_managed_objects",
+            load_history_from_managed_objects,
+        ),
+    ):
+        restore_discoveries_sync(mock_scanner, "hci1")
+
+    assert len(seen_devices) == 1
+
+
+@pytest.mark.asyncio
+async def test_restore_discoveries_sync_no_manager(mock_linux: None) -> None:
+    """restore_discoveries_sync is a no-op when no manager is running."""
+    mock_backend = Mock(seen_devices={})
+    with patch.object(bleak_retry_connector.bleak_manager, "_global_instances", {}):
+        restore_discoveries_sync(Mock(_backend=mock_backend), "hci0")
+    assert mock_backend.seen_devices == {}
+
+
+@pytest.mark.asyncio
+async def test_restore_discoveries_sync_non_linux(mock_macos: None) -> None:
+    """restore_discoveries_sync is a no-op off Linux."""
+    mock_backend = Mock(seen_devices={})
+    restore_discoveries_sync(Mock(_backend=mock_backend), "hci0")
     assert mock_backend.seen_devices == {}
 
 


### PR DESCRIPTION
`restore_discoveries` only awaits to obtain the global BlueZ manager; the work itself reads the manager in memory `_properties` cache. `restore_discoveries_sync` reads the manager bleak already created for the running loop and does the same without awaiting, a no-op when there is none. For habluetooth, which flips a running scanner between active and passive under a lock and needs to re-seed `seen_devices` after bleak clears it on `start()` (Bluetooth-Devices/habluetooth#621).

- [x] tests for the sync path, full suite passes
