### PR TITLE
fix: find devices on adapters above hci8

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -716,3 +716,21 @@ manager to attach to.
   disconnect wait in `establish_connection` — to complete before giving up.
   Exposed so callers wrapping the same D-Bus operations can apply a matching
   ceiling.
+
+- **`bleak_retry_connector.bluez.MAX_ADAPTER`** (`16`): Highest BlueZ adapter
+  number searched when a device is looked up across adapters. A device's
+  D-Bus path is probed on `hci0` through `hci16` inclusive, which covers
+  hosts with up to seventeen controllers. BlueZ has no fixed upper bound on
+  adapter numbers and they climb as controllers are re-plugged, so a host
+  that reaches higher can raise the limit at startup, before the first
+  connection attempt. The value is read on every lookup. It lives on the
+  `bluez` module and is not re-exported from the package, so set it there:
+
+  ```python
+  import bleak_retry_connector.bluez
+
+  bleak_retry_connector.bluez.MAX_ADAPTER = 40
+  ```
+
+  Each lookup costs one dictionary probe per adapter number, so keep the
+  value close to the adapters the host actually has.

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -574,12 +574,21 @@ def address_to_bluez_path(address: str, adapter: str | None = None) -> str:
     return f"/org/bluez/{adapter or 'hciX'}/dev_{address.upper().replace(':', '_')}"
 
 
+# BlueZ names adapters hci0, hci1, ... with no fixed upper bound: a host with
+# several USB controllers can have adapters numbered into the teens, and the
+# number climbs further as adapters are re-plugged. Probe a generous range so a
+# device on a higher-numbered adapter is still found. The previous limit of
+# hci0-hci8 missed hci9 and up.
+MAX_ADAPTER = 20
+
+
 def _get_possible_paths(path: str) -> Generator[str]:
-    """Get the possible paths."""
-    # The path is deterministic so we splice up the string
-    # /org/bluez/hci2/dev_FA_23_9D_AA_45_46
-    for i in range(0, 9):
-        yield f"{path[0:14]}{i}{path[15:]}"
+    """Get the possible paths for a device across adapters."""
+    # The same device address appears under every adapter it is known on, so
+    # rebuild the path for each: /org/bluez/hci2/dev_FA_23_9D_AA_45_46
+    _, _, device = path.partition("/dev_")
+    for i in range(MAX_ADAPTER + 1):
+        yield f"/org/bluez/hci{i}/dev_{device}"
 
 
 def ble_device_from_properties(path: str, props: dict[str, Any]) -> BLEDevice:

--- a/src/bleak_retry_connector/bluez.py
+++ b/src/bleak_retry_connector/bluez.py
@@ -576,10 +576,16 @@ def address_to_bluez_path(address: str, adapter: str | None = None) -> str:
 
 # BlueZ names adapters hci0, hci1, ... with no fixed upper bound: a host with
 # several USB controllers can have adapters numbered into the teens, and the
-# number climbs further as adapters are re-plugged. Probe a generous range so a
-# device on a higher-numbered adapter is still found. The previous limit of
-# hci0-hci8 missed hci9 and up.
-MAX_ADAPTER = 20
+# number climbs further as adapters are re-plugged. Device paths are probed on
+# hci0 through hci<MAX_ADAPTER> inclusive. The previous limit of hci0-hci8
+# missed hci9 and up.
+#
+# The value is read on every call, so a host with adapters numbered above the
+# default can raise it at startup, before the first connection attempt:
+#
+#     import bleak_retry_connector.bluez
+#     bleak_retry_connector.bluez.MAX_ADAPTER = 40
+MAX_ADAPTER = 16
 
 
 def _get_possible_paths(path: str) -> Generator[str]:

--- a/tests/test_bluez.py
+++ b/tests/test_bluez.py
@@ -1523,7 +1523,19 @@ def test_get_possible_paths_reaches_high_numbered_adapters() -> None:
     paths = list(_get_possible_paths("/org/bluez/hciX/dev_FA_23_9D_AA_45_46"))
     assert "/org/bluez/hci0/dev_FA_23_9D_AA_45_46" in paths
     assert "/org/bluez/hci9/dev_FA_23_9D_AA_45_46" in paths
-    assert "/org/bluez/hci19/dev_FA_23_9D_AA_45_46" in paths
+    assert "/org/bluez/hci16/dev_FA_23_9D_AA_45_46" in paths
+    assert "/org/bluez/hci17/dev_FA_23_9D_AA_45_46" not in paths
+
+
+def test_get_possible_paths_honours_a_raised_max_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MAX_ADAPTER is read on every call, so a host with adapters numbered
+    above the default can raise it at startup without changing the library."""
+    monkeypatch.setattr(bleak_retry_connector.bluez, "MAX_ADAPTER", 40)
+    paths = list(_get_possible_paths("/org/bluez/hciX/dev_FA_23_9D_AA_45_46"))
+    assert "/org/bluez/hci40/dev_FA_23_9D_AA_45_46" in paths
+    assert len(paths) == 41
 
 
 def test_get_possible_paths_handles_a_multi_digit_input_adapter() -> None:

--- a/tests/test_bluez.py
+++ b/tests/test_bluez.py
@@ -16,6 +16,7 @@ from bleak_retry_connector import (
     device_source,
 )
 from bleak_retry_connector.bluez import (
+    _get_possible_paths,
     adapter_path_from_device_path,
     ble_device_from_properties,
     clear_cache,
@@ -1514,3 +1515,21 @@ async def test_get_connected_devices_no_properties(
         {"path": "/org/bluez/hci0/dev_FA_23_9D_AA_45_46"},
     )
     assert await get_connected_devices(device) == []
+
+
+def test_get_possible_paths_reaches_high_numbered_adapters() -> None:
+    """Regression: the search was capped at hci0-hci8, so a device on hci9
+    or higher was never found. See the fix in _get_possible_paths."""
+    paths = list(_get_possible_paths("/org/bluez/hciX/dev_FA_23_9D_AA_45_46"))
+    assert "/org/bluez/hci0/dev_FA_23_9D_AA_45_46" in paths
+    assert "/org/bluez/hci9/dev_FA_23_9D_AA_45_46" in paths
+    assert "/org/bluez/hci19/dev_FA_23_9D_AA_45_46" in paths
+
+
+def test_get_possible_paths_handles_a_multi_digit_input_adapter() -> None:
+    """A device already resolved on a two-digit adapter must still enumerate
+    the single-digit adapters; the old fixed-index splice mangled these."""
+    paths = list(_get_possible_paths("/org/bluez/hci10/dev_FA_23_9D_AA_45_46"))
+    assert "/org/bluez/hci0/dev_FA_23_9D_AA_45_46" in paths
+    assert "/org/bluez/hci9/dev_FA_23_9D_AA_45_46" in paths
+    assert all(p.endswith("/dev_FA_23_9D_AA_45_46") for p in paths)


### PR DESCRIPTION
### The bug

`_get_possible_paths` enumerates a device's paths across adapters with `for i in range(0, 9)`, so it only ever probes hci0 through hci8. A host with several USB controllers reaches hci9 and beyond (mine has ten adapters today), and a device whose only cached path is on hci9 or higher is never found: `get_bluez_device` skips past it, and connection path selection and RSSI based path switching never see it.

There is a second, latent bug in the same function. It builds each candidate by splicing a fixed index, `f"{path[0:14]}{i}{path[15:]}"`, which assumes the input adapter number is a single digit. Once a device is resolved on a two digit adapter, `path[15:]` keeps the second digit and every generated path is malformed, so raising the range alone would not make higher adapters work.

### The fix

Rebuild the path from the device suffix instead of splicing a fixed offset, and take the upper bound from a module constant:

```python
MAX_ADAPTER = 16


def _get_possible_paths(path: str) -> Generator[str]:
    _, _, device = path.partition("/dev_")
    for i in range(MAX_ADAPTER + 1):
        yield f"/org/bluez/hci{i}/dev_{device}"
```

This probes hci0 through hci16 inclusive, covering hosts with up to seventeen controllers, and is correct regardless of how many digits the input adapter has. hci9, the case that prompted this, is well within range.

### Raising the bound

BlueZ has no fixed upper limit on adapter numbers and they climb as controllers are re-plugged, so a fixed ceiling always has the shape of a problem one controller further out. Rather than pick a very large default, the constant is read on every lookup, so a host that reaches higher can raise it at startup before the first connection attempt:

```python
import bleak_retry_connector.bluez

bleak_retry_connector.bluez.MAX_ADAPTER = 40
```

This is documented in the Constants section of `docs/source/usage.md`, alongside the other tunables, and in the comment above the constant. It is deliberately not re-exported from the package: rebinding a name on the package would not change the value the `bluez` module reads.

On cost: the loop is one dict lookup per adapter number. `range(17)` measured about 2.3 us per call against roughly 1.3 us for the old `range(9)` on a box with a few hundred cached objects, negligible on this path. The alternative of deriving the present adapters by scanning the managed objects cache on each call measured about 10x slower (roughly 21 us on the same box), so I kept the range probe. A cached set of present adapters kept in sync with InterfacesAdded and InterfacesRemoved would be fast and bound free, and I am happy to do that instead if you would rather not carry a constant.

### Tests

`tests/test_bluez.py` gains three tests: hci9 and hci16 are reachable and hci17 is not under the default; a raised `MAX_ADAPTER` is honoured; and a two digit input adapter still enumerates the lower adapters. The first and third fail on the current code and pass with the fix.
